### PR TITLE
Fix MCP autocomplete error due to XML parsing

### DIFF
--- a/cai/repl/commands/mcp.py
+++ b/cai/repl/commands/mcp.py
@@ -50,7 +50,6 @@ def debug_print(*args, **kwargs):
         escaped_args = []
         for arg in args:
             if isinstance(arg, str):
-                # Escape square brackets to prevent Rich markup interpretation
                 escaped_arg = arg.replace("[", "\\[").replace("]", "\\]")
                 escaped_args.append(escaped_arg)
             else:
@@ -413,7 +412,7 @@ class McpCommand(Command):
             description="Manage MCP server connections and tools",
             aliases=["/m"]
         )
-        # HTML-escape angle brackets to prevent parsing errors
+
         self._subcommands = {
             "load": "Connect to an MCP server: load {url} {label}",
             "unload": "Disconnect from an MCP server: unload {label}",


### PR DESCRIPTION
Error when autocomplete:

```
Unhandled exception in event loop:
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/buffer.py", line 1923, in new_coroutine
    await coroutine(*a, **kw)
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/buffer.py", line 1740, in async_completer
    async for completion in async_generator:
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/completion/base.py", line 310, in get_completions_async
    async for completion in completer.get_completions_async(
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/completion/base.py", line 268, in get_completions_async
    async for completion in async_generator:
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/eventloop/async_generator.py", line 125, in generator_to_async_generator
    await runner_f
  File "/opt/homebrew/anaconda3/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/eventloop/async_generator.py", line 78, in runner
    for item in get_iterable():
                ^^^^^^^^^^^^^^
  File "/Users/luijait/cybersecurityAI/cai/repl/commands/completer.py", line 656, in get_completions
    yield from self.get_subcommand_suggestions(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luijait/cybersecurityAI/cai/repl/commands/completer.py", line 408, in get_subcommand_suggestions
    display=HTML(
            ^^^^^
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/formatted_text/html.py", line 35, in __init__
    document = minidom.parseString(f"<html-root>{value}</html-root>")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/lib/python3.12/xml/dom/minidom.py", line 2000, in parseString
    return expatbuilder.parseString(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/lib/python3.12/xml/dom/expatbuilder.py", line 922, in parseString
    return builder.parseString(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/lib/python3.12/xml/dom/expatbuilder.py", line 220, in parseString
    parser.Parse(string, True)

Exception mismatched tag: line 1, column 105
Press ENTER to continue...

Unhandled exception in event loop:
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/buffer.py", line 1923, in new_coroutine
    await coroutine(*a, **kw)
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/buffer.py", line 1740, in async_completer
    async for completion in async_generator:
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/completion/base.py", line 310, in get_completions_async
    async for completion in completer.get_completions_async(
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/completion/base.py", line 268, in get_completions_async
    async for completion in async_generator:
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/eventloop/async_generator.py", line 125, in generator_to_async_generator
    await runner_f
  File "/opt/homebrew/anaconda3/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/eventloop/async_generator.py", line 78, in runner
    for item in get_iterable():
                ^^^^^^^^^^^^^^
  File "/Users/luijait/cybersecurityAI/cai/repl/commands/completer.py", line 656, in get_completions
    yield from self.get_subcommand_suggestions(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luijait/cybersecurityAI/cai/repl/commands/completer.py", line 408, in get_subcommand_suggestions
    display=HTML(
            ^^^^^
  File "/Users/luijait/cybersecurityAI/venv/lib/python3.12/site-packages/prompt_toolkit/formatted_text/html.py", line 35, in __init__
    document = minidom.parseString(f"<html-root>{value}</html-root>")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/lib/python3.12/xml/dom/minidom.py", line 2000, in parseString
    return expatbuilder.parseString(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/lib/python3.12/xml/dom/expatbuilder.py", line 922, in parseString
    return builder.parseString(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/lib/python3.12/xml/dom/expatbuilder.py", line 220, in parseString
    parser.Parse(string, True)
Exception mismatched tag: line 1, column 105
Press ENTER to continue...
CAI> /mcp lo
Unknown subcommand: lo
Command failed or not found: /mcp lo




```

Fix: Do not use these “<>” symbols when you want to define the help of a command. From none


https://github.com/user-attachments/assets/6e34e6a7-6fcb-4c30-991a-b49b5cf8b574


<img width="386" alt="Screenshot 2025-04-07 at 1 33 38 PM" src="https://github.com/user-attachments/assets/f2151ddd-3dd3-45ba-9ae2-c6114f4eefd1" />