### PR TITLE
Fix: Add stream options only when stream is True

### DIFF
--- a/cai/core.py
+++ b/cai/core.py
@@ -283,7 +283,7 @@ class CAI:  # pylint: disable=too-many-instance-attributes
                 create_params.pop("parallel_tool_calls", None)
             elif "deepseek" in create_params["model"]:
                 create_params.pop("parallel_tool_calls", None)
-            else:
+            if create_params["stream"] is True:
                 create_params["stream_options"] = {"include_usage": True}
             if not isinstance(agent, CodeAgent):  # Don't set temperature for CodeAgent  # noqa: E501
                 create_params["temperature"] = 0.7


### PR DESCRIPTION
The stream_options parameter is used to customize the behavior of the streaming response, and if streaming is not enabled (`stream=False`), including `stream_options` can result in an error or unnecessary processing.

Issue mentioned here:

https://github.com/aliasrobotics/cai/issues/77