### PR TITLE
Custom OpenAI API Base URL Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A lightweight, ergonomic framework for building bug bounty-ready Cybersecurity A
     - [Ubuntu 20.04](#ubuntu-2004)
     - [Windows WSL](#windows-wsl)
     - [:nut\_and\_bolt: Setup `.env` file](#nut_and_bolt-setup-env-file)
+    - [🔹 Custom OpenAI Base URL Support](#-custom-openai-base-url-support)
   - [:triangular\_ruler: Architecture:](#triangular_ruler-architecture)
     - [🔹 Agent](#-agent)
     - [🔹 Tools](#-tools)
@@ -231,6 +232,14 @@ CAI does NOT provide API keys for any model by default. Don't ask us to provide 
 
 The OPENAI_API_KEY must not be left blank. It should contain either "sk-123" (as a placeholder) or your actual API key. See https://github.com/aliasrobotics/cai/issues/27.
 
+### 🔹 Custom OpenAI Base URL Support
+
+CAI now supports configuring a custom OpenAI API base URL via the `OPENAI_BASE_URL` environment variable. This allows users to redirect API calls to a custom endpoint, such as a proxy or self-hosted OpenAI-compatible service. If not set, the default URL `https://api.openai.com/v1` is used.
+
+Example `.env` configuration:
+```bash
+OPENAI_BASE_URL="https://custom-openai-proxy.com/v1"
+```
 
 ## :triangular_ruler: Architecture:
 

--- a/cai/core.py
+++ b/cai/core.py
@@ -181,6 +181,8 @@ class CAI:  # pylint: disable=too-many-instance-attributes
         # load env variables
         load_dotenv()
 
+        # Set OpenAI API base URL
+        self.openai_base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
         openai_api_key = os.getenv("OPENAI_API_KEY")
         if not openai_api_key:
             os.environ["OPENAI_API_KEY"] = "sk-proj-1234567890"
@@ -275,6 +277,7 @@ class CAI:  # pylint: disable=too-many-instance-attributes
             "model": model_override or agent.model,
             "messages": messages,
             "stream": stream,
+            "api_base": self.openai_base_url,  # Use custom base URL
         }
         if tools:
             create_params["tools"] = tools

--- a/cai/rag/vector_db.py
+++ b/cai/rag/vector_db.py
@@ -97,9 +97,13 @@ class QdrantConnector:
                 if not api_key:
                     # Generate a random API key if none is provided
                     api_key = str(uuid.uuid4())
+                
+                # Get the custom OpenAI base URL from the environment variable
+                base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+                
                 self._openai_client = openai.Client(
                     api_key=api_key,
-                    base_url="https://api.openai.com/v1"
+                    base_url=base_url  # Use the custom base URL
                 )
         else:
             if self._model is None:


### PR DESCRIPTION
CAI now supports configuring a custom OpenAI API base URL via the `OPENAI_BASE_URL` environment variable. This allows users to redirect API calls to a custom endpoint, such as a proxy or self-hosted OpenAI-compatible service. If not set, the default URL `https://api.openai.com/v1` is used.

Example `.env` configuration:
```bash
OPENAI_BASE_URL="https://custom-openai-proxy.com/v1"
```