### PR TITLE
Create CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,9 @@
+@misc{mayoralvilches2025caiopenbugbountyready,
+      title={CAI: An Open, Bug Bounty-Ready Cybersecurity AI},
+      author={Víctor Mayoral-Vilches and Luis Javier Navarrete-Lozano and María Sanz-Gómez and Lidia Salas Espejo and Martiño Crespo-Álvarez and Francisco Oca-Gonzalez and Francesco Balassone and Alfonso Glera-Picón and Unai Ayucar-Carbajo and Jon Ander Ruiz-Alcalde and Stefan Rass and Martin Pinzger and Endika Gil-Uriarte},
+      year={2025},
+      eprint={2504.06017},
+      archivePrefix={arXiv},
+      primaryClass={cs.CR},
+      url={https://arxiv.org/abs/2504.06017},
+}


### PR DESCRIPTION
Adding a CITATION.cff file helps users to easily cite software from the repository overview.