### PR TITLE
Add missing PyPDF2 package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "mkdocs-material>=9.6.0",
     "paramiko>=3.5.1",
     "dnspython",
-    "flask"
+    "flask",
+    "PyPDF2,
 ]
 classifiers = [
     "Typing :: Typed",


### PR DESCRIPTION
There's a missing package when running the latest version of `cai` on the command line, as it throws the following error.

![image](https://github.com/user-attachments/assets/aa2ca1d4-5e19-4c1b-ae98-304de8e8ec3f)
