### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ CAI>/mcp load http://localhost:9876/sse burp
 
 2. **STDIO (Standard Input/Output)** - For local inter-process communication:
 ```bash
-CAI>/mcp stdio myserver python mcp_server.py
+CAI>/mcp load stdio myserver python mcp_server.py
 ```
 
 Once connected, you can add the MCP tools to any agent:


### PR DESCRIPTION
according to "CAI> /mcp help" it should be "/mcp load stdio" instead of "/mcp stdio"