### PR TITLE
fixed API endpoint for alias models

### DIFF
--- a/src/cai/sdk/agents/models/openai_chatcompletions.py
+++ b/src/cai/sdk/agents/models/openai_chatcompletions.py
@@ -2679,7 +2679,7 @@ class OpenAIChatCompletionsModel(Model):
         model_str = str(kwargs["model"]).lower()
 
         if "alias" in model_str:
-            kwargs["api_base"] = "http://api.aliasrobotics.com:666/"
+            kwargs["api_base"] = "https://api.aliasrobotics.com:666/"
             kwargs["custom_llm_provider"] = "openai"
             kwargs["api_key"] = os.getenv("ALIAS_API_KEY", "sk-alias-1234567890")
         elif "/" in model_str:


### PR DESCRIPTION
Current endpoint for alias models (e.g. alias0, alias0-fast) is incorrect. This PR changes the endpoint to use TLS so those models can be used from CAI.