### PR TITLE
Fix MCP command tool assignment and improve CLI error messaging

### DIFF
--- a/src/cai/cli.py
+++ b/src/cai/cli.py
@@ -1290,7 +1290,7 @@ def run_cai_cli(
 
                 # If command wasn't recognized, show error (skip for /shell or /s)
                 if command not in ("/shell", "/s"):
-                    console.print(f"[red]Unknown command: {command}[/red]")
+                    console.print(f"[red]Command failed or unknown: {command}[/red]")
                 continue
             from rich.text import Text
 

--- a/src/cai/repl/commands/mcp.py
+++ b/src/cai/repl/commands/mcp.py
@@ -116,11 +116,11 @@ class GlobalMCPUtil(MCPUtil):
         elif isinstance(server, MCPServerStdio):
             server_config["command"] = server.params.command
             server_config["args"] = server.params.args
-            server_config["env"] = server.params.get("env")
-            server_config["cwd"] = server.params.get("cwd")
-            server_config["encoding"] = server.params.get("encoding", "utf-8")
-            server_config["encoding_error_handler"] = server.params.get(
-                "encoding_error_handler", "strict"
+            server_config["env"] = getattr(server.params, "env")
+            server_config["cwd"] = getattr(server.params, "cwd")
+            server_config["encoding"] = getattr(server.params, "encoding", "utf-8")
+            server_config["encoding_error_handler"] = getattr(
+                server.params, "encoding_error_handler", "strict"
             )
 
         # Create a custom invoke function that creates a new connection each time
@@ -810,9 +810,9 @@ Example: `/mcp add burp 13`
 
         # Get the agent
         try:
-            agent = get_agent_by_name(agent_identifier)
+            agent = get_available_agents()[agent_identifier]
             agent_display_name = getattr(agent, "name", agent_identifier)
-        except ValueError:
+        except KeyError:
             # Try by index
             try:
                 agents = get_available_agents()


### PR DESCRIPTION
# Changes:
## 1. Fix incorrect attribute access for MCP server parameters
Replaced incorrect usage of `server.params.get("url")` with `getattr(server.params, "url")` to avoid runtime errors like:
`"Error adding tools: 'StdioServerParameters' object has no attribute 'get'"`
<img width="1070" height="150" alt="image" src="https://github.com/user-attachments/assets/e7fc6ec2-5dc4-49f5-a0d9-51916bc6270e" />

## 2. Fix Agent tool registration issue in MCP command handling
Fix the issue where the `/mcp add` command failed to correctly add tools to the corresponding Agent.
## 3. Improve fallback error messaging for failed or unknown CLI commands
Temporarily replace the vague `"Unknown command:"` output with a more informative `"Command failed or unknown:"` message to avoid ambiguity.  

- With these changes, the MCP command system should now operate properly.
- I'm not sure whether the fact that `/mcp remove` doesn't delete the corresponding tools from the Agent is intentional or a bug. If it's a bug, I might be able to help.
- I believe that, if possible, unknown commands and command execution errors should be distinguished in the future to make debugging easier.
