### PR TITLE
Improve MCP command messaging for existing servers

### DIFF
--- a/src/cai/repl/commands/mcp.py
+++ b/src/cai/repl/commands/mcp.py
@@ -602,8 +602,9 @@ Example: `/mcp add burp 13`
             True if successful
         """
         if name in _GLOBAL_MCP_SERVERS:
-            console.print(f"[yellow]Server '{name}' already exists. Remove it first.[/yellow]")
-            return False
+            console.print(f"[yellow]Server '{name}' is already loaded and active.[/yellow]")
+            console.print(f"[dim]Use '/mcp remove {name}' first if you want to reload it.[/dim]")
+            return True
 
         console.print(f"Connecting to SSE server at {url}...")
 
@@ -690,8 +691,9 @@ Example: `/mcp add burp 13`
             True if successful
         """
         if name in _GLOBAL_MCP_SERVERS:
-            console.print(f"[yellow]Server '{name}' already exists. Remove it first.[/yellow]")
-            return False
+            console.print(f"[yellow]Server '{name}' is already loaded and active.[/yellow]")
+            console.print(f"[dim]Use '/mcp remove {name}' first if you want to reload it.[/dim]")
+            return True
 
         console.print(
             f"Starting stdio server '{name}' with command: {command} {' '.join(cmd_args)}"


### PR DESCRIPTION
Updated the messages when attempting to add an already loaded server -> this should clarify that the server is active and there is no error

command: 
_/mcp load stdio enisa_vuln_db <...>_

output before: 
_Server 'enisa_vuln_db' already exists. Remove it first.
Command failed or unknown: /mcp_

output after:
_Server 'enisa_vuln_db' is already loaded and active.
Use '/mcp remove enisa_vuln_db' first if you want to reload it._
