### PR TITLE
Fix Async sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@ __pycache__/
 # C extensions
 *.so
 
+# Agent Framework Files
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+AGENTS*.md
+
 # Distribution / packaging
 .Python
 build/

--- a/src/cai/tools/common.py
+++ b/src/cai/tools/common.py
@@ -105,6 +105,11 @@ def _get_agent_token_info():
 # Global dictionary to store active sessions
 ACTIVE_SESSIONS = {}
 
+# Friendly IDs for sessions to simplify LLM control
+FRIENDLY_SESSION_MAP = {}  # friendly -> real session_id
+REVERSE_SESSION_MAP = {}   # real session_id -> friendly
+SESSION_COUNTER = 0
+
 # Global counter for session output commands to ensure they always display
 SESSION_OUTPUT_COUNTER = {}
 
@@ -173,6 +178,8 @@ class ShellSession:  # pylint: disable=too-many-instance-attributes
             self.workspace_dir = workspace_dir or _get_workspace_dir()
         else:
             self.workspace_dir = _get_workspace_dir()
+        self.friendly_id = None  # human-friendly alias like S1
+        self.created_at = time.time()
         self.process = None
         self.master = None
         self.slave = None
@@ -181,19 +188,21 @@ class ShellSession:  # pylint: disable=too-many-instance-attributes
         self.last_activity = time.time()
 
     def start(self):
-        """Start the shell session in the appropriate environment."""
-        start_message_cmd = self.command 
+        """Start the shell session in the appropriate environment.
+        Exactly one environment must be chosen to avoid duplicated processes.
+        """
+        start_message_cmd = self.command
 
         # --- Start in Container ---
         if self.container_id:
             try:
                 self.master, self.slave = pty.openpty()
                 docker_cmd_list = [
-                    "docker", "exec", "-i",
-                    "-w", self.workspace_dir, 
+                    "docker", "exec", "-i", "-t",  # allocate a TTY inside the container
+                    "-w", self.workspace_dir,
                     self.container_id,
-                    "sh", "-c", # Use shell to handle complex commands if needed
-                    self.command # The actual command to run
+                    "sh", "-c",
+                    self.command,
                 ]
                 self.process = subprocess.Popen(
                     docker_cmd_list,
@@ -201,13 +210,15 @@ class ShellSession:  # pylint: disable=too-many-instance-attributes
                     stdout=self.slave,
                     stderr=self.slave,
                     preexec_fn=os.setsid,
-                    universal_newlines=True
+                    universal_newlines=True,
                 )
                 self.is_running = True
                 self.output_buffer.append(
                     f"[Session {self.session_id}] Started in container {self.container_id[:12]}: "
-                    f"{start_message_cmd} in {self.workspace_dir}")
+                    f"{start_message_cmd} in {self.workspace_dir}"
+                )
                 threading.Thread(target=self._read_output, daemon=True).start()
+                return None
             except Exception as e:
                 self.output_buffer.append(f"Error starting container session: {str(e)}")
                 self.is_running = False
@@ -215,35 +226,39 @@ class ShellSession:  # pylint: disable=too-many-instance-attributes
 
         # --- Start in CTF ---
         if self.ctf:
-            self.is_running = True
-            self.output_buffer.append(
-                f"[Session {self.session_id}] Started CTF command: {self.command}")
             try:
+                self.is_running = True
+                self.output_buffer.append(
+                    f"[Session {self.session_id}] Started CTF command: {self.command}"
+                )
                 output = self.ctf.get_shell(self.command)
-                self.output_buffer.append(output)
+                if output:
+                    self.output_buffer.append(output)
+                # CTF "sessions" are request/response; mark as finished
+                self.is_running = False
+                return None
             except Exception as e:  # pylint: disable=broad-except
                 self.output_buffer.append(f"Error executing CTF command: {str(e)}")
-                self.is_running = False 
+                self.is_running = False
                 return str(e)
 
         # --- Start Locally (Host) ---
         try:
             self.master, self.slave = pty.openpty()
-            self.process = subprocess.Popen(  # pylint: disable=subprocess-popen-preexec-fn, consider-using-with # noqa: E501
-                self.command, 
-                shell=True,  # nosec B602 
+            self.process = subprocess.Popen(  # pylint: disable=subprocess-popen-preexec-fn
+                self.command,
+                shell=True,  # nosec B602
                 stdin=self.slave,
                 stdout=self.slave,
                 stderr=self.slave,
-                cwd=self.workspace_dir, 
+                cwd=self.workspace_dir,
                 preexec_fn=os.setsid,
-                universal_newlines=True
+                universal_newlines=True,
             )
             self.is_running = True
-            self.output_buffer.append(
-                f"[Session {self.session_id}] Started: {self.command}")
-            # Start a thread to read output
+            self.output_buffer.append(f"[Session {self.session_id}] Started: {self.command}")
             threading.Thread(target=self._read_output, daemon=True).start()
+            return None
         except Exception as e:  # pylint: disable=broad-except
             self.output_buffer.append(f"Error starting local session: {str(e)}")
             self.is_running = False
@@ -251,9 +266,6 @@ class ShellSession:  # pylint: disable=too-many-instance-attributes
     def _read_output(self):
         """Read output from the process"""
         try:
-            # Buffer for incomplete lines
-            partial_line = ""
-            
             while self.is_running and self.master is not None:
                 try:
                     # Check if process has exited before reading
@@ -261,28 +273,12 @@ class ShellSession:  # pylint: disable=too-many-instance-attributes
                         self.is_running = False
                         break
                     
-                    # Read the output - increased buffer size to avoid cutting commands
+                    # Read raw output chunk from PTY (don't require newlines)
                     output = os.read(self.master, 4096).decode('utf-8', errors='replace')
-                    
-                    if output:
-                        # Combine with any partial line from previous read
-                        full_output = partial_line + output
-                        
-                        # Split into lines but keep the last partial line if it doesn't end with newline
-                        lines = full_output.split('\n')
-                        
-                        # If output doesn't end with newline, the last item is a partial line
-                        if not output.endswith('\n'):
-                            partial_line = lines[-1]
-                            lines = lines[:-1]
-                        else:
-                            partial_line = ""
-                        
-                        # Add complete lines to buffer
-                        for line in lines:
-                            if line:  # Don't add empty lines
-                                self.output_buffer.append(line)
-                        
+
+                    if output is not None and output != "":
+                        # Append raw chunk so interactive tools (nc, tail -f) show partial states
+                        self.output_buffer.append(output)
                         self.last_activity = time.time()
                     else:
                         # os.read() returned empty. This does NOT necessarily mean
@@ -294,17 +290,14 @@ class ShellSession:  # pylint: disable=too-many-instance-attributes
                         else:
                             # Process is confirmed dead or no process to check,
                             # and read returned empty. Session is over.
-                            if partial_line:
-                                # Add any remaining partial line
-                                self.output_buffer.append(partial_line)
                             self.is_running = False
                             break
                 except UnicodeDecodeError as e:
                     # Handle unicode decode errors gracefully
-                    self.output_buffer.append(f"[Session {self.session_id}] Unicode decode error in output")
+                    self.output_buffer.append(f"[Session {self.session_id}] Unicode decode error in output\n")
                     continue
                 except Exception as read_err: 
-                    self.output_buffer.append(f"Error reading output buffer: {str(read_err)}")
+                    self.output_buffer.append(f"Error reading output buffer: {str(read_err)}\n")
                     self.is_running = False
                     break
                     
@@ -448,8 +441,15 @@ def create_shell_session(command, ctf=None, container_id=None, **kwargs):
         session = ShellSession(command, ctf=ctf, workspace_dir=workspace_dir)
 
     session.start()
-    if session.is_running or (ctf and not session.is_running): 
+    if session.is_running or (ctf and not session.is_running):
+         # Register session and assign friendly ID
+         global SESSION_COUNTER
+         SESSION_COUNTER += 1
+         friendly = f"S{SESSION_COUNTER}"
+         session.friendly_id = friendly
          ACTIVE_SESSIONS[session.session_id] = session
+         FRIENDLY_SESSION_MAP[friendly] = session.session_id
+         REVERSE_SESSION_MAP[session.session_id] = friendly
          return session.session_id
     else:
          error_msg = session.get_output(clear=True)
@@ -467,6 +467,7 @@ def list_shell_sessions():
             continue
 
         result.append({
+            "friendly_id": getattr(session, 'friendly_id', None),
             "session_id": session_id,
             "command": session.command,
             "running": session.is_running,
@@ -477,21 +478,57 @@ def list_shell_sessions():
     return result
 
 
+def _resolve_session_id(session_identifier):
+    """Resolve a session identifier which may be a real ID, a friendly alias (S1/#1/1), or 'last'."""
+    if not session_identifier:
+        return None
+    sid = str(session_identifier).strip()
+    # Accept patterns: S1, s1, #1, 1
+    key = sid
+    if sid.lower() == 'last':
+        # Return the most recently created active session
+        if not ACTIVE_SESSIONS:
+            return None
+        # Pick by created_at
+        latest = None
+        latest_t = -1
+        for _sid, sess in ACTIVE_SESSIONS.items():
+            if hasattr(sess, 'created_at') and sess.created_at > latest_t and sess.is_running:
+                latest = _sid
+                latest_t = sess.created_at
+        return latest or next(iter(ACTIVE_SESSIONS.keys()))
+    if sid.startswith('#'):
+        key = f"S{sid[1:]}"
+    elif sid.isdigit():
+        key = f"S{sid}"
+    elif sid.upper().startswith('S') and sid[1:].isdigit():
+        key = sid.upper()
+    # Real ID direct
+    if sid in ACTIVE_SESSIONS:
+        return sid
+    # Friendly map
+    if key in FRIENDLY_SESSION_MAP:
+        return FRIENDLY_SESSION_MAP[key]
+    return None
+
+
 def send_to_session(session_id, input_data):
     """Send input to a specific session"""
-    if session_id not in ACTIVE_SESSIONS:
+    resolved = _resolve_session_id(session_id)
+    if not resolved or resolved not in ACTIVE_SESSIONS:
         return f"Session {session_id} not found"
 
-    session = ACTIVE_SESSIONS[session_id]
+    session = ACTIVE_SESSIONS[resolved]
     return session.send_input(input_data)
 
 
 def get_session_output(session_id, clear=True, stdout=True):
     """Get output from a specific session"""
-    if session_id not in ACTIVE_SESSIONS:
+    resolved = _resolve_session_id(session_id)
+    if not resolved or resolved not in ACTIVE_SESSIONS:
         return f"Session {session_id} not found"
 
-    session = ACTIVE_SESSIONS[session_id]
+    session = ACTIVE_SESSIONS[resolved]
     output = session.get_output(clear)
     
     return output
@@ -499,13 +536,18 @@ def get_session_output(session_id, clear=True, stdout=True):
 
 def terminate_session(session_id):
     """Terminate a specific session"""
-    if session_id not in ACTIVE_SESSIONS:
+    resolved = _resolve_session_id(session_id)
+    if not resolved or resolved not in ACTIVE_SESSIONS:
         return f"Session {session_id} not found or already terminated."
 
-    session = ACTIVE_SESSIONS[session_id]
+    session = ACTIVE_SESSIONS[resolved]
     result = session.terminate()
-    if session_id in ACTIVE_SESSIONS:
-        del ACTIVE_SESSIONS[session_id]
+    if resolved in ACTIVE_SESSIONS:
+        del ACTIVE_SESSIONS[resolved]
+        # Clean friendly maps
+        friendly = REVERSE_SESSION_MAP.pop(resolved, None)
+        if friendly:
+            FRIENDLY_SESSION_MAP.pop(friendly, None)
     return result
 
 
@@ -1501,24 +1543,32 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
     try:
         # If session_id is provided, send command to that session
         if session_id:
-            if session_id not in ACTIVE_SESSIONS:
+            resolved_session_id = _resolve_session_id(session_id)
+            if not resolved_session_id or resolved_session_id not in ACTIVE_SESSIONS:
                 # Switch back to idle mode before returning error
                 stop_active_timer()
                 start_idle_timer()
                 return f"Session {session_id} not found"
-            session = ACTIVE_SESSIONS[session_id]
+            session = ACTIVE_SESSIONS[resolved_session_id]
             result = session.send_input(command) # Send the raw command string
             
             # Wait for the command to execute and capture output
             # This provides automatic output display for async sessions
-            wait_time = 3.0  # Wait 3 seconds for command to execute
+            # Tunable via env vars if needed
+            try:
+                wait_time = float(os.getenv("CAI_SESSION_WAIT", "3.0"))
+            except Exception:
+                wait_time = 3.0
             
             # Mark the current position in the output buffer before sending input
             session.get_new_output(mark_position=True)  # Reset position marker
             
             # Smart waiting: check for new output every 0.5 seconds, up to max wait time
             max_wait = wait_time
-            check_interval = 0.5
+            try:
+                check_interval = float(os.getenv("CAI_SESSION_CHECK_INTERVAL", "0.5"))
+            except Exception:
+                check_interval = 0.5
             elapsed = 0.0
             new_output_detected = False
             
@@ -1533,24 +1583,29 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
                 if current_new_output.strip():
                     if not new_output_detected:
                         new_output_detected = True
-                        # Give it a bit more time to complete the output
-                        time.sleep(0.5)
+                        # Give it a bit more time to complete the output (tunable)
+                        try:
+                            extra_delay = float(os.getenv("CAI_SESSION_POST_DETECT_DELAY", "0.5"))
+                        except Exception:
+                            extra_delay = 0.5
+                        time.sleep(extra_delay)
                     else:
                         # We already detected new output and waited, now break
                         break
             
             # Always show the session output after sending input using the counter mechanism
             # Generate unique counter for this session input command
-            counter_key = f"session_input_{session_id}"
+            counter_key = f"session_input_{resolved_session_id}"
             if counter_key not in SESSION_OUTPUT_COUNTER:
                 SESSION_OUTPUT_COUNTER[counter_key] = 0
             SESSION_OUTPUT_COUNTER[counter_key] += 1
             
             # Create args for display
+            label = getattr(session, 'friendly_id', None) or session_id
             session_args = {
                 "command": command,
                 "args": "",
-                "session_id": session_id,
+                "session_id": label,
                 "call_counter": SESSION_OUTPUT_COUNTER[counter_key],  # This ensures uniqueness
                 "input_to_session": True,  # Flag to identify this as session input
             }
@@ -1582,7 +1637,7 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
                 "status": "completed",
                 "environment": env_type,
                 "host": session.workspace_dir,
-                "session_id": session_id,
+                "session_id": label,
                 "wait_time": elapsed,
                 "new_output_detected": new_output_detected
             }
@@ -1640,7 +1695,7 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
                 session_creation_args = {
                     "command": command,
                     "args": "",
-                    "session_id": new_session_id,
+                    "session_id": getattr(ACTIVE_SESSIONS.get(new_session_id), 'friendly_id', None) or new_session_id,
                     "async_mode": True
                 }
                 
@@ -1649,7 +1704,7 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
                     "status": "session_created",
                     "environment": f"Container({container_id[:12]})",
                     "host": container_workspace,
-                    "session_id": new_session_id
+                    "session_id": getattr(ACTIVE_SESSIONS.get(new_session_id), 'friendly_id', None) or new_session_id
                 }
                 
                 # Get initial output if any
@@ -1660,7 +1715,8 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
                     initial_output = session.get_new_output(mark_position=True)
                 
                 # Format the output message
-                output_msg = f"Started async session {new_session_id} in container {container_id[:12]}. Use this ID to interact."
+                label = getattr(ACTIVE_SESSIONS.get(new_session_id), 'friendly_id', None) or new_session_id
+                output_msg = f"Started async session {label} in container {container_id[:12]}. Use this ID to interact."
                 if initial_output:
                     output_msg += f"\n\n{initial_output}"
                 
@@ -1679,7 +1735,7 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
                 # For async sessions, switch back to idle mode after session creation
                 stop_active_timer()
                 start_idle_timer()
-                return f"Started async session {new_session_id} in container {container_id[:12]}. Use this ID to interact." # noqa E501
+                return f"Started async session {label} in container {container_id[:12]}. Use this ID to interact." # noqa E501
 
             # Handle Streaming Container Execution
             if stream:
@@ -2250,7 +2306,7 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
             session_creation_args = {
                 "command": command,
                 "args": "",
-                "session_id": new_session_id,
+                "session_id": getattr(session, 'friendly_id', None) or new_session_id,
                 "async_mode": True
             }
             
@@ -2259,7 +2315,7 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
                 "status": "session_created",
                 "environment": "Local",
                 "host": os.path.basename(actual_workspace),
-                "session_id": new_session_id
+                "session_id": getattr(session, 'friendly_id', None) or new_session_id
             }
             
             # Get initial output if any
@@ -2269,7 +2325,8 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
                 initial_output = session.get_new_output(mark_position=True)
             
             # Format the output message
-            output_msg = f"Started async session {new_session_id} locally. Use this ID to interact."
+            label = getattr(session, 'friendly_id', None) or new_session_id
+            output_msg = f"Started async session {label} locally. Use this ID to interact."
             if initial_output:
                 output_msg += f"\n\n{initial_output}"
             
@@ -2286,7 +2343,7 @@ def run_command(command, ctf=None, stdout=False,  # pylint: disable=too-many-arg
             # For async, switch back to idle mode after session creation
             stop_active_timer()
             start_idle_timer()
-            return f"Started async session {new_session_id} locally. Use this ID to interact."
+            return f"Started async session {label} locally. Use this ID to interact."
 
         # Handle Synchronous Execution Locally
         # Pass stream parameter as provided (not always True)

--- a/tests/tools/test_tool_generic_linux_sessions.py
+++ b/tests/tools/test_tool_generic_linux_sessions.py
@@ -1,0 +1,69 @@
+import os
+import re
+import json
+import asyncio
+import pytest
+
+os.environ["OPENAI_API_KEY"] = "test_key_for_ci_environment"
+
+from cai.sdk.agents import RunContextWrapper
+from cai.tools.reconnaissance.generic_linux_command import generic_linux_command
+
+
+def _extract_alias(msg: str) -> str | None:
+    m = re.search(r"Started async session\s+(S\d+)", msg)
+    return m.group(1) if m else None
+
+
+@pytest.mark.asyncio
+async def test_interactive_session_create_and_io():
+    # Create a simple interactive session that emits one line then echoes stdin
+    cmd = "sh -c 'printf ready\\n; cat -'"
+    args = {"command": cmd, "interactive": True}
+    out = await generic_linux_command.on_invoke_tool(RunContextWrapper(None), json.dumps(args))
+    assert "Started async session" in out
+
+    alias = _extract_alias(out)
+    assert alias is not None
+
+    # Read initial output (should contain 'ready')
+    args = {"command": f"output {alias}"}
+    out = await generic_linux_command.on_invoke_tool(RunContextWrapper(None), json.dumps(args))
+    assert "ready" in out or "Started" in out
+
+    # Send a line and expect to see it echoed back by cat -
+    args = {"command": "hello-world", "session_id": alias}
+    out = await generic_linux_command.on_invoke_tool(RunContextWrapper(None), json.dumps(args))
+    assert "hello-world" in out
+
+    # Kill the session
+    args = {"command": f"kill {alias}"}
+    out = await generic_linux_command.on_invoke_tool(RunContextWrapper(None), json.dumps(args))
+    assert "terminated" in out.lower() or "already terminated" in out.lower()
+
+
+@pytest.mark.asyncio
+async def test_session_parsing_variants():
+    # New interactive session
+    cmd = "sh -c 'printf ready\\n; cat -'"
+    args = {"command": cmd, "interactive": True}
+    out = await generic_linux_command.on_invoke_tool(RunContextWrapper(None), json.dumps(args))
+    alias = _extract_alias(out)
+    assert alias is not None
+
+    # Old variant: command="session", session_id="output S#"
+    args = {"command": "session", "session_id": f"output {alias}"}
+    out = await generic_linux_command.on_invoke_tool(RunContextWrapper(None), json.dumps(args))
+    assert isinstance(out, str)
+    assert "Session" not in out or "not found" not in out
+
+    # status should return a string even if no new output
+    args = {"command": f"status {alias}"}
+    out = await generic_linux_command.on_invoke_tool(RunContextWrapper(None), json.dumps(args))
+    assert isinstance(out, str)
+
+    # Cleanup
+    await generic_linux_command.on_invoke_tool(
+        RunContextWrapper(None), json.dumps({"command": f"kill {alias}"})
+    )
+


### PR DESCRIPTION
- Refactored interactive session runtime for generic_linux_command and the shared shell utilities to:
    - Respect the LLM’s explicit intent for interactivity.
    - Provide simple, human-friendly session aliases (S1, S2, …) and tolerant session subcommands.
    - Correctly stream partial outputs from long-running, TTY-driven tools (REPLs, nc, tail -f).
    - Render clearer, consistent session state in panels/logs.
    - Add targeted tests covering interactive session creation, I/O, aliasing, and legacy invocation patterns.

Problem Statement

- Interactivity was implicitly forced based on command names, preventing the LLM from choosing the mode.
- Container sessions lacked a real TTY; many interactive tools behaved poorly or failed to render prompts.
- PTY reads were line-based; tools emitting output without a trailing newline looked “silent”.
- Session UX was confusing: only long UUIDs; “session output …” parsing was brittle; alias-based inputs failed.
- Outputs and session states were not consistently reflected, especially when the LLM mixed old/new calling styles.
(Big problem in a wide uses cases, like AD pentesting or Linux priv esc)

Key Changes

- Respect LLM Intent
    - session_id present → send input to that session.
    - interactive=True → create a persistent session only if the command is plausibly interactive; otherwise do a one-shot run.
    - interactive=False (or omitted) → one-shot run.
- TTY and Output Capture
    - Container sessions use docker exec -it with an allocated PTY.
    - Switch PTY reading from line-based to raw chunk aggregation to surface partial/streamed states.
- Simple Session Aliases
    - Assign friendly aliases S1, S2, … on creation; display them alongside short UUIDs.
    - New resolver accepts S1, #1, 1, last, and the real UUID everywhere session IDs are used.
- Tolerant Session Commands
    - Accepted forms: sessions, output <id>, status <id>, kill <id>, and legacy session output <id>, etc.
    - If the LLM sends command="session" with session_id="output S1", it is handled gracefully.
- Clearer Messages
    - Creation messages show “Started async session S1 …”.
    - Session input panels include the alias to keep interactions consistent and readable.
- CTF Execution Semantics
    - Run-and-return behavior stays in CTF (no accidental local fallback).
- Configurable Waits
    - Tunables after sending input to a session:
    - CAI_SESSION_WAIT (default 3.0s)
    - CAI_SESSION_CHECK_INTERVAL (default 0.5s)
    - CAI_SESSION_POST_DETECT_DELAY (default 0.5s)

Behavioral Notes

- One-shot vs. session:
    - When interactive=True, we only open a persistent session if the command looks interactive (shells, REPLs, tools with -i/-it, streamers like tail -f, etc.). Otherwise we fall back to one-shot to avoid
zombie sessions.
- FTP example:
    - Use a numeric port (21) with tnftp to avoid “Servname not supported …” errors.

Backwards Compatibility

- No breaking API changes. Existing UUID-based flows still work.
- Legacy “session …” forms are supported; new forms are simpler and additive.
- Panels/logs now include friendly aliases, improving readability without altering tool interfaces.

New Environment Variables

- CAI_SESSION_WAIT: seconds to wait after sending input before collecting output.
- CAI_SESSION_CHECK_INTERVAL: polling interval for new output during the wait window.
- CAI_SESSION_POST_DETECT_DELAY: extra delay once first new output is detected to capture a coherent chunk.

Tests Added

- tests/tools/test_tool_generic_linux_sessions.py
    - test_interactive_session_create_and_io:
    - Creates an interactive session (`sh -c 'printf ready\n; cat -'`), extracts alias (S1), verifies initial output, sends input via `session_id=alias`, expects echo, then kills the session.
- test_session_parsing_variants:
    - Verifies legacy invocation (`command="session", session_id="output S1"`), `status S1` behavior, and cleanup with `kill`.
- These tests avoid external dependencies and focus on PTY + session behavior.

Files Touched

- Modified:
    - src/cai/tools/common.py
    - src/cai/tools/reconnaissance/generic_linux_command.py
- Added:
    - tests/tools/test_tool_generic_linux_sessions.py

Risk and Mitigation

- PTY behavior differs across environments: we allocate a real PTY (+ -it in containers) to normalize behavior. Raw-chunk buffering can show partial lines by design (accurate for interactive tools).
- Alias lifecycle: aliases are per-process and ephemeral; UUIDs remain supported for robustness.
- CTF: preserved single-environment execution to prevent dual-start issues.

Migration Guide (If Any)

- None required. Recommend adopting new subcommands and aliases for clarity:
    - List sessions: sessions
    - Read output: output S1
    - Non-destructive check: status S1
    - Terminate: kill S1
    - Send input: generic_linux_command("<input>", session_id="S1")

- Extend docs/examples for network/DFIR agents using aliases and status polling.
- Prioritize explicit control by the LLM (no hidden auto-interactivity).
- Make session management trivial to parse and robust to minor variations.
- Ensure interactive tools behave naturally (TTY + partial output streaming).
- Improve operator/LLM ergonomics without breaking existing usage.

NOTE 2

- Scope: This PR touched a hot file, src/cai/tools/reconnaissance/generic_linux_command.py, and unified two lines of work: interactive-session semantics and guardrails. During rebase you may see that file
“both modified”.
Scope: This PR touched a hot file, src/cai/tools/reconnaissance/generic_linux_command.py, and unified two lines of work: interactive-session semantics and guardrails. During rebase you may see that file
“both modified”.

Conflict resolution policy (what to keep):
    - Keep the new interactive-session behavior: session_id routes to an existing session; interactive=True opens a persistent TTY session only for truly interactive commands; otherwise run one-shot.
    - Keep the flexible session commands: sessions | output  | status  | kill , plus legacy “session …” forms.
    - Keep the guardrails: Unicode homograph checks, pre-exec dangerous-pattern blocking (curl|sh, wget|bash, tmp+$(…)), base64/base32 decode checks, and post-exec wrapping of curl/wget/fetch output.
   
Safety guarantees after merge:
    - No API shape changes; UUID session IDs remain valid; alias IDs (S1, #1, 1, last) are additive.
    - Container sessions use TTY; PTY reader is chunk-based to surface partial output; session subcommands are tolerant.

   
https://github.com/user-attachments/assets/f533895b-9920-4707-ba1a-d176fab568fe

