### PR TITLE
Added missing step in OSX install documentation.

### DIFF
--- a/docs/cai/getting-started/installation.md
+++ b/docs/cai/getting-started/installation.md
@@ -6,6 +6,10 @@ pip install cai-framework
 
 ## OS X
 ```bash
+# Install homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Install dependencies
 brew update && \
     brew install git python@3.12
 


### PR DESCRIPTION
New user had issues installing CAI in OSX due to incomplete documentation.