### PR TITLE
Enhance reasoning_tokens handling in response processing

### DIFF
--- a/src/cai/sdk/agents/models/openai_chatcompletions.py
+++ b/src/cai/sdk/agents/models/openai_chatcompletions.py
@@ -760,7 +760,17 @@ class OpenAIChatCompletionsModel(Model):
                 and response.usage.completion_tokens_details
                 and hasattr(response.usage.completion_tokens_details, "reasoning_tokens")
             ):
-                reasoning_tokens = response.usage.completion_tokens_details.reasoning_tokens
+                # Guard against None or unexpected types for reasoning_tokens
+                try:
+                    reasoning_tokens = response.usage.completion_tokens_details.reasoning_tokens
+                    if reasoning_tokens is None:
+                        reasoning_tokens = 0
+                    else:
+                        # coerce numeric-like values to int
+                        reasoning_tokens = int(reasoning_tokens)
+                except Exception:
+                    reasoning_tokens = 0
+
                 self.total_reasoning_tokens += reasoning_tokens
             
             # Process costs for non-streaming mode


### PR DESCRIPTION
Fixed a runtime crash in CAI caused by adding a None value to an integer token counter. I guarded the reasoning-token extraction so the code never tries to do int += None.
