### PR TITLE
Fix missing import `sys`.

### DIFF
--- a/src/cai/sdk/agents/models/openai_chatcompletions.py
+++ b/src/cai/sdk/agents/models/openai_chatcompletions.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import time
+import sys
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, cast, overload


### PR DESCRIPTION
During CAI’s execution, pressing **Ctrl-C** triggers an error.
The cause is that at [L1923](https://github.com/aliasrobotics/cai/blob/054f3038de4a19148534bed55fad754bd7c8c4e8/src/cai/sdk/agents/models/openai_chatcompletions.py#L1922), the code uses `sys.stderr` but the **`sys`** module has not been imported.

```
  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/litellm/litellm_core_utils/streaming_handler.py", line 948, in chunk_creator
    model_response = self.model_response_creator()
  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/litellm/litellm_core_utils/streaming_handler.py", line 654, in model_response_creator
    model_response = ModelResponseStream(**args)
  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/litellm/types/utils.py", line 1050, in __init__
    def __init__(

  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/cai/util.py", line 202, in signal_handler
    raise KeyboardInterrupt()
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/cai/cli.py", line 1486, in process_streamed_response
    async for event in stream_iterator:
    ...<19 lines>...
                    agent.model.add_to_message_history(tool_msg)
  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/cai/sdk/agents/result.py", line 186, in stream_events
    raise self._stored_exception
  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/cai/sdk/agents/run.py", line 608, in _run_streamed_impl
    turn_result = await cls._run_single_turn_streamed(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<8 lines>...
    )
    ^
  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/cai/sdk/agents/run.py", line 754, in _run_single_turn_streamed
    async for event in model.stream_response(
    ...<27 lines>...
        streamed_result._event_queue.put_nowait(RawResponsesStreamEvent(data=event))
  File "/home/kali/Desktop/cai/cai_env/lib/python3.13/site-packages/cai/sdk/agents/models/openai_chatcompletions.py", line 1902, in stream_response
    print("\n[Streaming interrupted by user]", file=sys.stderr)
                                                    ^^^
NameError: name 'sys' is not defined. Did you forget to import 'sys'?
```