### PR TITLE
feat: Add HTTP header support to /mcp load command for SSE servers

### DIFF
--- a/src/cai/cli.py
+++ b/src/cai/cli.py
@@ -141,6 +141,7 @@ if os.getenv("CAI_DEBUG", "1") != "2":
 
 import asyncio
 import logging
+import shlex
 import time
 
 # Configure comprehensive error filtering
@@ -1295,7 +1296,19 @@ def run_cai_cli(
 
             # Handle special commands
             if user_input.startswith("/") or user_input.startswith("$"):
-                parts = user_input.strip().split()
+                # Remove newlines from pasted input
+                cleaned_input = user_input.strip().replace('\n', '').replace('\r', '')
+
+                try:
+                    # Parse with shell-like quoting support
+                    parts = shlex.split(cleaned_input)
+                except ValueError:
+                    # Fallback to simple split on error
+                    parts = cleaned_input.split()
+
+                if not parts:
+                    continue
+
                 command = parts[0]
                 args = parts[1:] if len(parts) > 1 else None
 


### PR DESCRIPTION
## Summary
Adds HTTP header support to the `/mcp load` command for SSE MCP servers, enabling authentication with servers that require Bearer tokens or API keys (e.g., Hack The Box MCP). As far as I can tell, this PR addresses issue #340 

## Problem
MCP servers like Hack The Box require authentication headers to connect, but the `/mcp load` command didn't support passing custom HTTP headers. This prevented users from connecting to authenticated MCP servers.

**During implementation, we discovered a second issue:** When pasting long commands (like `/mcp load` with long Bearer tokens), terminal line wrapping introduces newline characters into the pasted text. The CLI's `.split()` method was treating these newlines as delimiters, breaking tokens into multiple arguments and causing authentication to fail.

## Solution
- Added `--header` / `-H` flag support to `/mcp load` command for SSE servers
- Headers are parsed in "Key: Value" format with quote stripping
- Fixed CLI command parsing to handle newlines from terminal line wrapping
  - Strip newline characters from pasted input before parsing
  - Use `shlex.split()` for proper shell-like quote handling instead of simple `.split()`

## Changes
**Files modified:**
- `src/cai/cli.py`: Strip newlines from pasted input before parsing with shlex
- `src/cai/repl/commands/mcp.py`: Add header flag parsing and pass to MCPServerSseParams

## Usage
```bash
# Single header
/mcp load https://mcp.ai.hackthebox.com/v1/ctf/sse htb --header "Authorization: Bearer TOKEN"

# Multiple headers
/mcp load https://api.example.com/sse myserver -H "X-API-Key: key1" -H "Custom-Header: value"
```

## Tests

Loading mcp with header
<img width="928" height="999" alt="Screenshot from 2025-11-23 23-52-33" src="https://github.com/user-attachments/assets/e5cae60a-cf05-4226-a069-32258f053746" />

Confirming loaded tools
<img width="928" height="999" alt="image" src="https://github.com/user-attachments/assets/9b87b65a-6eba-4895-bf1a-63a4a68d3292" />

**Note**: my claude model doesn't seem to be able to use these mcp tools for some reason, no matter what prompt I use. I'm not sure if I'm doing something wrong, but I decided this is outside of the scope of this PR.

---

*Implementation by Claude Sonnet 4 with guidance from @AgeOfAlgorithms*