### PR TITLE
Add web_request_framework tool to web_pentester

### DIFF
--- a/src/cai/agents/web_pentester.py
+++ b/src/cai/agents/web_pentester.py
@@ -13,6 +13,7 @@ from cai.agents.guardrails import get_security_guardrails
 # Core tools
 from cai.tools.reconnaissance.generic_linux_command import generic_linux_command
 from cai.tools.reconnaissance.exec_code import execute_code
+from cai.tools.web.headers import web_request_framework
 
 # Optional OSINT search (requires PERPLEXITY_API_KEY)
 from cai.tools.web.search_web import make_web_search_with_explanation
@@ -27,6 +28,7 @@ web_pentester_system_prompt = load_prompt_template("prompts/system_web_pentester
 tools = [
     generic_linux_command,   # shell one-liners (httpie/curl/waybackurls/etc if installed)
     execute_code,            # light parsing/diffing/payload crafting
+    web_request_framework,   # HTTP request + response/header security analysis
 ]
 
 # Conditional: add web search helper when available

--- a/src/cai/tools/web/headers.py
+++ b/src/cai/tools/web/headers.py
@@ -8,8 +8,10 @@ analysis, parameter inspection, and security vulnerability detection.
 
 from urllib.parse import urlparse
 import requests  # pylint: disable=E0401
+from cai.sdk.agents import function_tool
 
 
+@function_tool(strict_mode=False)
 def web_request_framework(  # noqa: E501 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
                             url: str = "",
                             method: str = "GET",


### PR DESCRIPTION
Summary:

    - add @function_tool(strict_mode=False) to web_request_framework
    - include web_request_framework in Web App Pentester tool list

Testing:

    - PYTHONPATH=src python3 - <<'PY'
      from cai.agents.web_pentester import web_pentester_agent
      print([t.name for t in web_pentester_agent.tools])
      PY

    - (optional) PYTHONPATH=src python3 - <<'PY'
      from cai.tools.web.headers import web_request_framework
      print(web_request_framework(url="https://httpbin.org/headers").split("\n")[:10])
      PY