### PR TITLE
[FIXED] Docker Image with bad mirror

### DIFF
--- a/dockerized/Dockerfile
+++ b/dockerized/Dockerfile
@@ -2,6 +2,9 @@ FROM kalilinux/kali-rolling
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# [FIX BAD MIRROR] Use a single, reliable Kali mirror to avoid flaky mirror redirects during apt operations
+RUN printf 'deb http://kali.download/kali kali-rolling main contrib non-free non-free-firmware\n' > /etc/apt/sources.list
+
 # Fix Kali GPG Keys
 RUN apt-get update --allow-insecure-repositories && \
     apt-get install -y --no-install-recommends --allow-unauthenticated kali-archive-keyring && \


### PR DESCRIPTION
Your build is failing because `apt-get` is trying to fetch a few packages from the `mirror1.sox.rs` Kali mirror, which is timing out. That’s a mirror problem, not a package problem:

•  Errors like Unable to connect to `mirror1.sox.rs:80` and `E: Unable to fetch some archives` show the mirror is down/unreachable during the image build.
•  Docker then aborts that RUN `apt-get install` ... layer with `exit code 100`.

To make the build reliable, I updated the Dockerfile to force Kali to use a `single`, `stable` mirror (kali.download) instead of relying on the default `redirector` that might pick broken mirrors.