### PR TITLE
[Docs] Fix broken links in Installation Guides (CAI Pro v0.5 & v0.6)

### DIFF
--- a/docs/Installation_Guide_for_CAI_Pro_v0.5.md
+++ b/docs/Installation_Guide_for_CAI_Pro_v0.5.md
@@ -1,6 +1,6 @@
 # Installation Guide for CAI Pro v0.5
 
-← [Back to Installation Guide](../README.md#nut_and_bolt-install)
+← [Back to Installation Guide](cai_installation.md)
 
 ## Welcome to CAI Pro!
 
@@ -135,5 +135,5 @@ cai
 
 ---
 
-**[⬅️ Return to Main Installation Guide](../README.md#nut_and_bolt-install)**
+**[⬅️ Return to Main Installation Guide](cai_installation.md)**
 

--- a/docs/Installation_Guide_for_CAI_Pro_v0.6.md
+++ b/docs/Installation_Guide_for_CAI_Pro_v0.6.md
@@ -1,6 +1,6 @@
 # Installation Guide for CAI Pro v0.6
 
-← [Back to Installation Guide](../README.md#nut_and_bolt-install)
+← [Back to Installation Guide](cai_installation.md)
 
 ## Welcome to CAI Pro!
 
@@ -137,5 +137,5 @@ cai
 
 ---
 
-**[⬅️ Return to Main Installation Guide](../README.md#nut_and_bolt-install)**
+**[⬅️ Return to Main Installation Guide](cai_installation.md)**
 


### PR DESCRIPTION
### Description
This PR fixes the broken "Back to Installation Guide" links in `Installation_Guide_for_CAI_Pro_v0.6.md` and `v0.5.md`.

### Issue
Previously, the links pointed to `../README.md` (root path). This caused **404 errors** because the relative path was incorrect when accessing from the `/docs/` directory.

### Solution
I updated the links to point to `/docs/cai_installation.md`, which is the correct file for the installation guide.

### Verification
I have verified locally that the links now correctly redirect to the intended installation page.