### PR TITLE
Fix duplicate API calls causing hang with Anthropic streaming

### DIFF
--- a/src/cai/sdk/agents/models/openai_chatcompletions.py
+++ b/src/cai/sdk/agents/models/openai_chatcompletions.py
@@ -3305,7 +3305,6 @@ class OpenAIChatCompletionsModel(Model):
         try:
             if stream:
                 # Standard LiteLLM handling for streaming
-                ret = await litellm.acompletion(**kwargs)
                 stream_obj = await litellm.acompletion(**kwargs)
 
                 response = Response(
@@ -3359,7 +3358,6 @@ class OpenAIChatCompletionsModel(Model):
                 kwargs["messages"] = messages
                 # Retry once, silently
                 if stream:
-                    ret = await litellm.acompletion(**kwargs)
                     stream_obj = await litellm.acompletion(**kwargs)
                     response = Response(
                         id=FAKE_RESPONSES_ID,


### PR DESCRIPTION
fixes #401
## Changelog

- Remove duplicate `litellm.acompletion()` call in streaming path (line 3308)
- Remove duplicate `litellm.acompletion()` call in retry path (line 3362)
- Each streaming request now makes only one API call instead of two

## Context

When using Anthropic API keys with CAI, the application would hang or appear very slow. Investigation revealed that the streaming code was making **two identical API calls** for every request, then discarding the result of the first one.

The bug was in `_fetch_response_litellm_openai()` where:
```python
ret = await litellm.acompletion(**kwargs)      # First call - DISCARDED
stream_obj = await litellm.acompletion(**kwargs)  # Second call - used
```

This caused:
- 2x latency on every streaming request
- 2x token usage
- Apparent "hanging" behavior while waiting for the first (wasted) call

## Testing and Deployment

- Tested with Anthropic API key - requests now return promptly instead of hanging
- No new environment variables or deployment changes required
- The fix is a simple removal of duplicate lines