### PR TITLE
Fix broken image paths in README FAQ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,7 @@ curl -v http://host.docker.internal:8000/api/version
 <details>
 <summary>Run CAI against any target</summary>
 
-![cai-004-first-message](imgs/readme_imgs/cai-004-first-message.png)
+![cai-004-first-message](docs/media/cai-004-first-message.png)
 
 The starting user prompt in this case is: `Target IP: 192.168.3.10, perform a full network scan`.
 
@@ -1090,7 +1090,7 @@ The agent started performing a nmap scan. You could either interact with the age
 <details>
 <summary>How do I interact with the agent? Type twice CTRL + C </summary>
 
-![cai-005-ctrl-c](imgs/readme_imgs/cai-005-ctrl-c.png)
+![cai-005-ctrl-c](docs/media/cai-005-ctrl-c.png)
 
 If you want to use the HITL mode, you can do it by presssing twice ```Ctrl + C```.
 This will allow you to interact (prompt) with the agent whenever you want. The agent will not lose the previous context, as it is stored in the `history` variable, which is passed to it and any agent that is called. This enables any agent to use the previous information and be more accurate and efficient.
@@ -1101,7 +1101,7 @@ This will allow you to interact (prompt) with the agent whenever you want. The a
 
 Use ```/model``` to change the model.
 
-![cai-007-model-change](imgs/readme_imgs/cai-007-model-change.png)
+![cai-007-model-change](docs/media/cai-007-model-change.png)
 
 </details>
 
@@ -1111,7 +1111,7 @@ Use ```/model``` to change the model.
 
 Use ```/agent``` to list all the agents available.
 
-![cai-010-agents-menu](imgs/readme_imgs/cai-010-agents-menu.png)
+![cai-010-agents-menu](docs/media/cai-010-agents-menu.png)
 
 </details>
 
@@ -1120,7 +1120,7 @@ Use ```/agent``` to list all the agents available.
 <details>
 <summary> Where can I list all the environment variables? /config </summary>
 
-![cai-008-config](imgs/readme_imgs/cai-008-config.png)
+![cai-008-config](docs/media/cai-008-config.png)
 </details>
 
 <details>
@@ -1158,7 +1158,7 @@ This command displays:
 <details>
 <summary> How to know more about the CLI? /help </summary>
 
-![cai-006-help](imgs/readme_imgs/cai-006-help.png)
+![cai-006-help](docs/media/cai-006-help.png)
 </details>
 
 
@@ -1167,7 +1167,7 @@ This command displays:
 The environment variable `CAI_TRACING` allows the user to set it to `CAI_TRACING=true` to enable tracing, or `CAI_TRACING=false` to disable it.
 When CAI is prompted by the first time, the user is provided with two paths, the execution log, and the tracing log.
 
-![cai-009-logs](imgs/readme_imgs/cai-009-logs.png)
+![cai-009-logs](docs/media/cai-009-logs.png)
 
 </details>
 
@@ -1189,7 +1189,7 @@ CAI>/load <file> parallel                        # Match to configured parallel 
 
 CAI prints the path to the current run’s JSONL log at startup (highlighted in orange), which you can pass to `/load`:
 
-![cai-009-logs](imgs/readme_imgs/cai-009-logs.png)
+![cai-009-logs](docs/media/cai-009-logs.png)
 
 Legacy notes: earlier “memory extension” mechanisms (episodic/semantic stores and offline ingestion) are retained for reference only. See [src/cai/agents/memory.py](src/cai/agents/memory.py) for background and legacy details. Our current direction prioritizes ICL over persistent memory.
 


### PR DESCRIPTION
## Summary

- Updates 8 image references in the README FAQ section from the old `imgs/readme_imgs/` path to the correct `docs/media/` path
- All referenced images exist at `docs/media/` — the old `imgs/readme_imgs/` directory does not exist, causing all FAQ images to fail loading

## Changes

All occurrences of:
```markdown
![image](imgs/readme_imgs/cai-XXX.png)
```
Updated to:
```markdown
![image](docs/media/cai-XXX.png)
```

Affected images: `cai-004` through `cai-010` (8 references total).

Fixes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)