### PR TITLE
update-scaffolds

### DIFF
--- a/docs/other_cli/claude_code.md
+++ b/docs/other_cli/claude_code.md
@@ -1,0 +1,96 @@
+# Claude Code
+
+!!! danger "Third-Party Scaffolding — Privacy & Security Warning"
+    Third-party scaffoldings may be serving your data outside your environment.
+    For **privacy** and **cybersecurity refusal optimization**, use **CAI** to obtain the best performance.
+
+Claude Code is Anthropic's official CLI for agentic coding. Because it speaks the **Anthropic API format** natively, it cannot talk directly to the Alias API (which is OpenAI-compatible). A small proxy is required to translate between the two.
+
+!!! warning "Support Disclaimer"
+    Alias Robotics **does not provide support** for developments or integrations related to Claude Code. This page documents API compatibility only. Alias simply allows usage of the Alias API through your preferred scaffolding.
+
+---
+
+## How It Works
+
+```
+Claude Code  →  Anthropic API format
+                        ↓
+              claude-code-proxy (localhost:8082)
+                        ↓
+              OpenAI-compatible format  →  Alias API
+```
+
+The proxy ([github.com/1rgs/claude-code-proxy](https://github.com/1rgs/claude-code-proxy)) intercepts Anthropic-format requests from Claude Code and forwards them to any OpenAI-compatible backend — in this case, the Alias API.
+
+---
+
+## Setup
+
+### 1. Get your Alias API Key
+
+An `ALIAS_API_KEY` (format: `sk-...`) can be obtained from either of the following:
+
+- **[CAI PRO](https://aliasrobotics.com/cybersecurityai.php)** — full cybersecurity AI platform with access to `alias1` and other models.
+- **[Alias LLMs](https://aliasrobotics.com/aliasLLMs.php)** — acquire `alias2-mini` and other Alias language models directly.
+
+### 2. Clone and configure the proxy
+
+```bash
+git clone https://github.com/1rgs/claude-code-proxy.git
+cd claude-code-proxy
+```
+
+Create a `.env` file:
+
+```bash
+# Point to the Alias API
+OPENAI_API_KEY="sk-your-alias-api-key-here"
+OPENAI_BASE_URL="https://api.aliasrobotics.com:666/"
+
+# Map Claude model names to Alias models
+BIG_MODEL="alias1"
+SMALL_MODEL="alias1"
+
+PREFERRED_PROVIDER="openai"
+```
+
+### 3. Run the proxy
+
+Install `uv` if needed, then start the server:
+
+```bash
+uv run uvicorn server:app --host 0.0.0.0 --port 8082 --reload
+```
+
+Or with Docker:
+
+```bash
+docker run -d --env-file .env -p 8082:8082 ghcr.io/1rgs/claude-code-proxy:latest
+```
+
+### 4. Launch Claude Code via the proxy
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:8082 claude
+```
+
+To avoid setting this every time, export it in your shell profile:
+
+```bash
+echo 'export ANTHROPIC_BASE_URL=http://localhost:8082' >> ~/.zshrc
+```
+
+---
+
+## Verification
+
+Inside Claude Code, run a quick prompt and confirm the response is served via `alias1`. Token usage and billing will appear in your Alias account.
+
+---
+
+## Related
+
+- [CAI PRO Quickstart](../cai_pro_quickstart.md)
+- [Available Models](../cai_list_of_models.md)
+- [Environment Variables](../environment_variables.md)

--- a/docs/other_cli/claude_code.md
+++ b/docs/other_cli/claude_code.md
@@ -4,28 +4,36 @@
     Third-party scaffoldings may be serving your data outside your environment.
     For **privacy** and **cybersecurity refusal optimization**, use **CAI** to obtain the best performance.
 
-Claude Code is Anthropic's official CLI for agentic coding. Because it speaks the **Anthropic API format** natively, it cannot talk directly to the Alias API (which is OpenAI-compatible). A small proxy is required to translate between the two.
-
 !!! warning "Support Disclaimer"
     Alias Robotics **does not provide support** for developments or integrations related to Claude Code. This page documents API compatibility only. Alias simply allows usage of the Alias API through your preferred scaffolding.
 
 ---
 
-## How It Works
+## Step 1: Install Claude Code
 
-```
-Claude Code  →  Anthropic API format
-                        ↓
-              claude-code-proxy (localhost:8082)
-                        ↓
-              OpenAI-compatible format  →  Alias API
+### Prerequisites
+
+- **Node.js 18** or newer
+- For **macOS**, use [nvm](https://github.com/nvm-sh/nvm) to install Node.js — installing the package directly may cause permission issues
+- For **Windows**, additionally install [Git for Windows](https://gitforwindows.org/)
+
+```bash
+# Install Claude Code
+npm install -g @anthropic-ai/claude-code
+
+# Navigate to your project
+cd your-awesome-project
+
+# Launch
+claude
 ```
 
-The proxy ([github.com/1rgs/claude-code-proxy](https://github.com/1rgs/claude-code-proxy)) intercepts Anthropic-format requests from Claude Code and forwards them to any OpenAI-compatible backend — in this case, the Alias API.
+!!! note
+    If macOS users encounter permission issues during installation, use `nvm` to install Node.js.
 
 ---
 
-## Setup
+## Step 2: Configure the Alias API
 
 ### 1. Get your Alias API Key
 
@@ -34,58 +42,59 @@ An `ALIAS_API_KEY` (format: `sk-...`) can be obtained from either of the followi
 - **[CAI PRO](https://aliasrobotics.com/cybersecurityai.php)** — full cybersecurity AI platform with access to `alias1` and other models.
 - **[Alias LLMs](https://aliasrobotics.com/aliasLLMs.php)** — acquire `alias2-mini` and other Alias language models directly.
 
-### 2. Clone and configure the proxy
+### 2. Configure Environment Variables
 
-```bash
-git clone https://github.com/1rgs/claude-code-proxy.git
-cd claude-code-proxy
+Set up environment variables using one of the following methods for macOS/Linux or Windows.
+
+!!! note
+    Some commands show no output when setting environment variables — that's normal as long as no errors appear. A new terminal window may be required for the changes to take effect.
+
+#### macOS & Linux
+
+Edit the Claude Code configuration file `~/.claude/settings.json`. Add or modify the `env` fields `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`.
+
+Replace `your_alias_api_key` with the API Key you obtained in the previous step.
+
+```json
+{
+    "env": {
+        "ANTHROPIC_AUTH_TOKEN": "your_alias_api_key",
+        "ANTHROPIC_BASE_URL": "https://api.aliasrobotics.com:666/",
+        "API_TIMEOUT_MS": "3000000"
+    }
+}
 ```
 
-Create a `.env` file:
+#### Windows Cmd
 
-```bash
-# Point to the Alias API
-OPENAI_API_KEY="sk-your-alias-api-key-here"
-OPENAI_BASE_URL="https://api.aliasrobotics.com:666/"
+Run the following commands in Cmd. Replace `your_alias_api_key` with the API Key you obtained in the previous step.
 
-# Map Claude model names to Alias models
-BIG_MODEL="alias1"
-SMALL_MODEL="alias1"
-
-PREFERRED_PROVIDER="openai"
+```cmd
+setx ANTHROPIC_AUTH_TOKEN your_alias_api_key
+setx ANTHROPIC_BASE_URL https://api.aliasrobotics.com:666/
 ```
 
-### 3. Run the proxy
+#### Windows PowerShell
 
-Install `uv` if needed, then start the server:
+Run the following commands in PowerShell. Replace `your_alias_api_key` with the API Key you obtained in the previous step.
 
-```bash
-uv run uvicorn server:app --host 0.0.0.0 --port 8082 --reload
-```
-
-Or with Docker:
-
-```bash
-docker run -d --env-file .env -p 8082:8082 ghcr.io/1rgs/claude-code-proxy:latest
-```
-
-### 4. Launch Claude Code via the proxy
-
-```bash
-ANTHROPIC_BASE_URL=http://localhost:8082 claude
-```
-
-To avoid setting this every time, export it in your shell profile:
-
-```bash
-echo 'export ANTHROPIC_BASE_URL=http://localhost:8082' >> ~/.zshrc
+```powershell
+[System.Environment]::SetEnvironmentVariable('ANTHROPIC_AUTH_TOKEN', 'your_alias_api_key', 'User')
+[System.Environment]::SetEnvironmentVariable('ANTHROPIC_BASE_URL', 'https://api.aliasrobotics.com:666/', 'User')
 ```
 
 ---
 
-## Verification
+## Step 3: Start with Claude Code
 
-Inside Claude Code, run a quick prompt and confirm the response is served via `alias1`. Token usage and billing will appear in your Alias account.
+Once the configuration is complete, start using Claude Code in your terminal:
+
+```bash
+cd your-project-directory
+claude
+```
+
+Token usage and billing will appear in your Alias account.
 
 ---
 

--- a/docs/other_cli/codex.md
+++ b/docs/other_cli/codex.md
@@ -1,0 +1,72 @@
+# Codex CLI
+
+!!! danger "Third-Party Scaffolding — Privacy & Security Warning"
+    Third-party scaffoldings may be serving your data outside your environment.
+    For **privacy** and **cybersecurity refusal optimization**, use **CAI** to obtain the best performance.
+
+[Codex CLI](https://github.com/openai/codex) is OpenAI's open-source terminal-based AI coding agent. Because it uses the **OpenAI API format** natively, it can connect directly to the Alias API without any proxy.
+
+!!! warning "Support Disclaimer"
+    Alias Robotics **does not provide support** for developments or integrations related to Codex CLI. This page documents API compatibility only. Alias simply allows usage of the Alias API through your preferred scaffolding.
+
+---
+
+## Setup
+
+### 1. Get your Alias API Key
+
+An `ALIAS_API_KEY` (format: `sk-...`) can be obtained from either of the following:
+
+- **[CAI PRO](https://aliasrobotics.com/cybersecurityai.php)** — full cybersecurity AI platform with access to `alias1` and other models.
+- **[Alias LLMs](https://aliasrobotics.com/aliasLLMs.php)** — acquire `alias2-mini` and other Alias language models directly.
+
+### 2. Install Codex CLI
+
+```bash
+npm install -g @openai/codex
+```
+
+### 3. Configure environment variables
+
+```bash
+export OPENAI_API_KEY="sk-your-alias-api-key-here"
+export OPENAI_BASE_URL="https://api.aliasrobotics.com:666/"
+```
+
+To persist these, add them to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.):
+
+```bash
+echo 'export OPENAI_API_KEY="sk-your-alias-api-key-here"' >> ~/.zshrc
+echo 'export OPENAI_BASE_URL="https://api.aliasrobotics.com:666/"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+### 4. Run Codex with an Alias model
+
+```bash
+codex --model alias1
+```
+
+Or set the model inline per session:
+
+```bash
+OPENAI_API_KEY="sk-your-alias-api-key-here" \
+OPENAI_BASE_URL="https://api.aliasrobotics.com:666/" \
+codex --model alias1
+```
+
+---
+
+## Notes
+
+- The Alias API is fully OpenAI-compatible — no additional configuration is required beyond pointing the base URL and API key.
+- Use `alias1` for best cybersecurity performance, or `alias0` for a faster, lighter alternative.
+- Token usage and billing appear in your Alias account dashboard.
+
+---
+
+## Related
+
+- [CAI PRO Quickstart](../cai_pro_quickstart.md)
+- [Available Models](../cai_list_of_models.md)
+- [Environment Variables](../environment_variables.md)

--- a/docs/other_cli/opencode.md
+++ b/docs/other_cli/opencode.md
@@ -1,0 +1,91 @@
+# OpenCode
+
+!!! danger "Third-Party Scaffolding — Privacy & Security Warning"
+    Third-party scaffoldings may be serving your data outside your environment.
+    For **privacy** and **cybersecurity refusal optimization**, use **CAI** to obtain the best performance.
+
+[OpenCode](https://opencode.ai) is an open-source, terminal-based AI coding assistant. It supports OpenAI-compatible providers, which means the Alias API can be plugged in directly without any proxy.
+
+!!! warning "Support Disclaimer"
+    Alias Robotics **does not provide support** for developments or integrations related to OpenCode. This page documents API compatibility only. Alias simply allows usage of the Alias API through your preferred scaffolding.
+
+---
+
+## Setup
+
+### 1. Get your Alias API Key
+
+An `ALIAS_API_KEY` (format: `sk-...`) can be obtained from either of the following:
+
+- **[CAI PRO](https://aliasrobotics.com/cybersecurityai.php)** — full cybersecurity AI platform with access to `alias1` and other models.
+- **[Alias LLMs](https://aliasrobotics.com/aliasLLMs.php)** — acquire `alias2-mini` and other Alias language models directly.
+
+### 2. Install OpenCode
+
+```bash
+npm install -g opencode-ai
+```
+
+Or via Homebrew (macOS):
+
+```bash
+brew install sst/tap/opencode
+```
+
+### 3. Configure the Alias provider
+
+OpenCode uses a `~/.config/opencode/config.json` file. Add a custom OpenAI-compatible provider pointing to the Alias API:
+
+```json
+{
+  "provider": {
+    "alias": {
+      "api": "https://api.aliasrobotics.com:666/",
+      "name": "Alias Robotics",
+      "env": ["ALIAS_API_KEY"]
+    }
+  },
+  "model": "alias/alias1"
+}
+```
+
+Then export your key:
+
+```bash
+export ALIAS_API_KEY="sk-your-alias-api-key-here"
+```
+
+### 4. Run OpenCode
+
+```bash
+opencode
+```
+
+OpenCode will pick up the configured provider and route requests to the Alias API.
+
+---
+
+## Alternative: environment variable approach
+
+If you prefer not to edit the config file, OpenCode also respects standard OpenAI environment variables:
+
+```bash
+export OPENAI_API_KEY="sk-your-alias-api-key-here"
+export OPENAI_BASE_URL="https://api.aliasrobotics.com:666/"
+opencode --model alias1
+```
+
+---
+
+## Notes
+
+- Use `alias1` for best cybersecurity performance, or `alias0` for a faster, lighter alternative.
+- Token usage and billing appear in your Alias account dashboard.
+
+---
+
+## Related
+
+- [CAI PRO Quickstart](../cai_pro_quickstart.md)
+- [Available Models](../cai_list_of_models.md)
+- [Environment Variables](../environment_variables.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,14 @@ nav:
           - Advanced Usage: cli/advanced_usage.md
 
   # ========================================
+  # SUPPORTING OTHER CLIs
+  # ========================================
+  - Supporting Other CLIs:
+      - Claude Code: other_cli/claude_code.md
+      - Codex CLI: other_cli/codex.md
+      - OpenCode: other_cli/opencode.md
+
+  # ========================================
   # CORE CONCEPTS
   # ========================================
   - Core Concepts:


### PR DESCRIPTION
## Summary
- Adds documentation for using the Alias API with third-party CLI tools: **Claude Code**, **Codex CLI**, and **OpenCode**
- Each page includes setup instructions, API key configuration, and relevant warnings about third-party scaffoldings
- Updates `mkdocs.yml` navigation with a new "Supporting Other CLIs" section

## Test plan
- [ ] Verify the docs build correctly with `mkdocs serve`
- [ ] Check all internal links resolve (CAI PRO Quickstart, Available Models, Environment Variables)
- [ ] Confirm the new nav section renders properly in the sidebar