### PR TITLE
docs: environment variable REPL reference and /help var parity

### DIFF
--- a/docs/cai/getting-started/configuration.md
+++ b/docs/cai/getting-started/configuration.md
@@ -16,6 +16,8 @@ The OPENAI_API_KEY must not be left blank. It should contain either "sk-123" (as
 
 For a complete reference organized by use case, see [Environment Variables Reference](../../environment_variables.md).
 
+**In the REPL:** `/config` (or `/config list`) shows variables with **current values** and index numbers. **`/help`** includes the **full environment reference** (tables) after the quick guide; **`/help var NAME`** opens **long-form** help for a single variable. See also [Environment Variables — Discovering variables in the REPL](../../environment_variables.md#discovering-variables-in-the-repl).
+
 | Variable | Description | Default |
 |----------|-------------|---------|
 | CTF_NAME | Name of the CTF challenge to run (e.g. "picoctf_static_flag") | - |

--- a/docs/cai_faq.md
+++ b/docs/cai_faq.md
@@ -86,6 +86,12 @@
 
 ??? question "Where can I list all the environment variables? /config"
 
+    Use **`/config`** (or **`/config list`**) to see all variables with **current values** and index numbers for `/config set`.
+    
+    For **full documentation tables** (defaults, constraints, when each applies), run **`/help`** and scroll past the quick guide, or **`/help topics`** and read to the end. For **one variable** in depth, use **`/help var VARIABLE_NAME`** (e.g. `/help var CAI_DEBUG`).
+    
+    The same topics are covered on the site in [Environment Variables](environment_variables.md).
+    
     ![cai-008-config](media/cai-008-config.png)
 
 ??? question "How to know more about the CLI? /help"

--- a/docs/cli/cli_index.md
+++ b/docs/cli/cli_index.md
@@ -94,7 +94,7 @@ Over 30 built-in commands organized by category:
 
 - **Agent Management**: `/agent`, `/parallel`, `/run`
 - **Memory & History**: `/memory`, `/history`, `/compact`, `/flush`, `/load`, `/merge`
-- **Environment & Config**: `/config`, `/env`, `/workspace`, `/virtualization`
+- **Environment & Config**: `/config`, `/env`, `/help var` (per-variable help), `/workspace`, `/virtualization`
 - **Tools & Integration**: `/mcp`, `/platform`, `/shell`
 - **Utilities**: `/model`, `/graph`, `/context`, `/cost`, `/help`
 

--- a/docs/cli/commands_reference.md
+++ b/docs/cli/commands_reference.md
@@ -976,18 +976,26 @@ Display help information and command documentation.
 /help [command]
 /h [command]
 /? [command]
+/help var [VARIABLE_NAME...]
 ```
 
 **Examples**:
 
 ```bash
-# General help
+# General help (includes quick guide; full environment-variable tables below)
 CAI> /help
+
+# Structured overview (welcome, categories, tips) + same env tables at the end
+CAI> /help topics
 
 # Help for specific command
 CAI> /help agent
 CAI> /h parallel
 CAI> /? mcp
+
+# Long-form help for one environment variable (see also /config for live values)
+CAI> /help var
+CAI> /help var CAI_MODEL
 ```
 
 **Topics**:
@@ -995,6 +1003,7 @@ CAI> /? mcp
 - `parallel`: Parallel execution
 - `memory`: Memory management
 - `config`: Configuration
+- `var`: Environment variables — long-form help per variable (full tables appear under bare `/help` and `/help topics`)
 - `mcp`: MCP integration
 - `commands`: List all commands
 

--- a/docs/cli/getting_started.md
+++ b/docs/cli/getting_started.md
@@ -214,11 +214,14 @@ Here are the most important commands to know:
 ### Getting Help
 
 ```bash
-# General help
+# General help (quick guide; full environment-variable tables below)
 CAI> /help
 
 # Help for specific command
 CAI> /help agent
+
+# Long-form help for one environment variable
+CAI> /help var CAI_MODEL
 
 # Quick reference guide
 CAI> /quickstart

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -4,39 +4,75 @@ This comprehensive guide documents all environment variables available in CAI, i
 
 ---
 
+## 🔎 Discovering variables in the REPL
+
+In current CAI releases, you can explore environment variables **from inside the interactive CLI** without leaving the session:
+
+| What you need | Command |
+|---------------|---------|
+| **Numbered list with live values** (what is set *now*) | `/config` or `/config list` |
+| **Full reference tables** (defaults, allowed values, when they apply, extras) | `/help` — scroll past the quick guide; or `/help topics` for the overview first, then the same tables at the end |
+| **Long-form help for one variable** (examples, `/config` index when listed, notes) | `/help var VARIABLE_NAME` (e.g. `/help var CAI_MODEL`) |
+
+Aliases such as `/h` for `/help` work the same way. This page remains the **canonical web reference**; the REPL output tracks the version you have installed.
+
+---
+
+## 📖 Fields explained (same model as `/help var NAME`)
+
+In the REPL, **`/help var VARIABLE_NAME`** expands each variable with the same ideas used below:
+
+| Field | Meaning |
+|-------|---------|
+| **Description** | What the variable controls (see the next table). |
+| **Values** | Value *type* or documented range (e.g. `bool`, `int 0–2`, `string`) — same notion as the **Values** column in the large `/help` tables. |
+| **When** | **Runtime** — often picked up on each use via `os.getenv`. **Restart** — typically read only at process start (new session recommended). **Mixed** — in `os.environ` but parts of CAI may cache until the next turn, agent switch, or restart. |
+| **Default** | Documented default when unset or as shipped. |
+
+**How to set (matches `/help` copy):**
+
+- Before launch: `export VAR=value` or a line in `.env`, then start CAI.
+- During a session: `/config set <number> <value>`, `/config VAR=value`, or code updating `os.environ`.
+
+**Types (short):** *bool* — `true`/`false`, `1`/`0`, etc.; *string* — free text; *int* / *float* — numeric; ranges in **Values** are the usual bounds CAI documents; *secret* — treat like a string, never commit real keys.
+
+For **numbered `/config` index**, **extra notes**, and **copy-paste examples** per variable, use **`/help var NAME`** in the REPL — the web page keeps one compact table for browsing.
+
+---
+
 ## 📋 Complete Reference Table
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| CTF_NAME | Name of the CTF challenge to run (e.g. "picoctf_static_flag") | - |
-| CTF_CHALLENGE | Specific challenge name within the CTF to test | - |
-| CTF_SUBNET | Network subnet for the CTF container | 192.168.3.0/24 |
-| CTF_IP | IP address for the CTF container | 192.168.3.100 |
-| CTF_INSIDE | Whether to conquer the CTF from within container | true |
-| CAI_MODEL | Model to use for agents | alias1 |
-| CAI_DEBUG | Set debug output level (0: Only tool outputs, 1: Verbose debug output, 2: CLI debug output) | 1 |
-| CAI_BRIEF | Enable/disable brief output mode | false |
-| CAI_MAX_TURNS | Maximum number of turns for agent interactions | inf |
-| CAI_MAX_INTERACTIONS | Maximum number of interactions (tool calls, agent actions, etc.) allowed in a session. If exceeded, only CLI commands are allowed until increased. If force_until_flag=true, the session will exit | inf |
-| CAI_PRICE_LIMIT | Price limit for the conversation in dollars. If exceeded, only CLI commands are allowed until increased. If force_until_flag=true, the session will exit | 1 |
-| CAI_TRACING | Enable/disable OpenTelemetry tracing. When enabled, traces execution flow and agent interactions for debugging and analysis | true |
-| CAI_AGENT_TYPE | Specify the agents to use (e.g., boot2root, one_tool, redteam_agent). Use "/agent" command in CLI to list all available agents | redteam_agent |
-| CAI_STATE | Enable/disable stateful mode. When enabled, the agent will use a state agent to keep track of the state of the network and the flags found | false |
-| CAI_MEMORY | Enable/disable memory mode (episodic: use episodic memory, semantic: use semantic memory, all: use both episodic and semantic memory) | false |
-| CAI_MEMORY_ONLINE | Enable/disable online memory mode | false |
-| CAI_MEMORY_OFFLINE | Enable/disable offline memory | false |
-| CAI_ENV_CONTEXT | Add environment context, dirs and current env available | true |
-| CAI_MEMORY_ONLINE_INTERVAL | Number of turns between online memory updates | 5 |
-| CAI_SUPPORT_MODEL | Model to use for the support agent | o3-mini |
-| CAI_SUPPORT_INTERVAL | Number of turns between support agent executions | 5 |
-| CAI_STREAM | Enable/disable streaming output in rich panel | false |
-| CAI_TELEMETRY | Enable/disable telemetry | true |
-| CAI_PARALLEL | Number of parallel agent instances to run. When set to values greater than 1, executes multiple instances of the same agent in parallel and displays all results | 1 |
-| CAI_GUARDRAILS | Enable/disable security guardrails for agents. When set to "true", applies security guardrails to prevent potentially dangerous outputs and inputs | false |
-| CAI_GCTR_NITERATIONS | Number of tool interactions before triggering GCTR (Generative Cut-The-Rope) analysis in bug_bounter_gctr agent. Only applies when using gctr-enabled agents | 5 |
-| CAI_ACTIVE_CONTAINER | Docker container ID where commands should be executed. When set, shell commands and tools execute inside the specified container instead of the host. Automatically set when CTF challenges start (if CTF_INSIDE=true) or when switching containers via /virtualization command | - |
-| CAI_TOOL_TIMEOUT | Override the default timeout for tool command executions in seconds. When set, this value overrides all default timeouts for shell commands and tool executions | varies (10s for interactive, 100s for regular) |
-| C99_API_KEY | API key for C99.nl subdomain discovery service. Required for using the C99 reconnaissance tool for DNS enumeration and subdomain discovery. Obtain from [C99.nl](https://c99.nl) | - |
+| Variable | Description | Values | When | Default |
+|----------|-------------|------|------|---------|
+| CTF_NAME | Name of the CTF challenge to run (e.g. "picoctf_static_flag") | string | Mixed | - |
+| CTF_CHALLENGE | Specific challenge name within the CTF to test | string | Mixed | - |
+| CTF_SUBNET | Network subnet for the CTF container | string | Mixed | 192.168.3.0/24 |
+| CTF_IP | IP address for the CTF container | string | Mixed | 192.168.3.100 |
+| CTF_INSIDE | Whether to conquer the CTF from within container | bool | Mixed | true |
+| CAI_MODEL | Model to use for agents | string | Mixed | alias1 |
+| CAI_DEBUG | Set debug output level (0: Only tool outputs, 1: Verbose debug output, 2: CLI debug output) | int 0–2 | Mixed | 1 |
+| CAI_BRIEF | Enable/disable brief output mode | bool | Mixed | false |
+| CAI_MAX_TURNS | Maximum number of turns for agent interactions | int ≥1 | Mixed | inf |
+| CAI_MAX_INTERACTIONS | Maximum number of interactions (tool calls, agent actions, etc.) allowed in a session. If exceeded, only CLI commands are allowed until increased. If force_until_flag=true, the session will exit | int ≥1 | Mixed | inf |
+| CAI_PRICE_LIMIT | Price limit for the conversation in dollars. If exceeded, only CLI commands are allowed until increased. If force_until_flag=true, the session will exit | float ≥0 | Mixed | 1 |
+| CAI_TRACING | Enable/disable OpenTelemetry tracing. When enabled, traces execution flow and agent interactions for debugging and analysis | bool | Restart | true |
+| CAI_AGENT_TYPE | Specify the agents to use (e.g., boot2root, one_tool, redteam_agent). Use "/agent" command in CLI to list all available agents | string | Mixed | redteam_agent |
+| CAI_STATE | Enable/disable stateful mode. When enabled, the agent will use a state agent to keep track of the state of the network and the flags found | bool | Mixed | false |
+| CAI_MEMORY | Enable/disable memory mode (episodic: use episodic memory, semantic: use semantic memory, all: use both episodic and semantic memory) | string | Mixed | false |
+| CAI_MEMORY_ONLINE | Enable/disable online memory mode | bool | Mixed | false |
+| CAI_MEMORY_OFFLINE | Enable/disable offline memory | bool | Mixed | false |
+| CAI_ENV_CONTEXT | Add environment context, dirs and current env available | bool | Mixed | true |
+| CAI_MEMORY_ONLINE_INTERVAL | Number of turns between online memory updates | int | Mixed | 5 |
+| CAI_SUPPORT_MODEL | Model to use for the support agent | string | Mixed | o3-mini |
+| CAI_SUPPORT_INTERVAL | Number of turns between support agent executions | int | Mixed | 5 |
+| CAI_STREAM | Enable/disable streaming output in rich panel | bool | Runtime | false |
+| CAI_TELEMETRY | Enable/disable telemetry | bool | Restart | true |
+| CAI_PARALLEL | Number of parallel agent instances to run. When set to values greater than 1, executes multiple instances of the same agent in parallel and displays all results | int 1–20 | Mixed | 1 |
+| CAI_GUARDRAILS | Enable/disable security guardrails for agents. When set to "true", applies security guardrails to prevent potentially dangerous outputs and inputs | bool | Runtime | false |
+| CAI_GCTR_NITERATIONS | Number of tool interactions before triggering GCTR (Generative Cut-The-Rope) analysis in bug_bounter_gctr agent. Only applies when using gctr-enabled agents | int | Mixed | 5 |
+| CAI_ACTIVE_CONTAINER | Docker container ID where commands should be executed. When set, shell commands and tools execute inside the specified container instead of the host. Automatically set when CTF challenges start (if CTF_INSIDE=true) or when switching containers via /virtualization command | string | Mixed | - |
+| CAI_TOOL_TIMEOUT | Override the default timeout for tool command executions in seconds. When set, this value overrides all default timeouts for shell commands and tool executions | int (s) | Runtime | varies (10s for interactive, 100s for regular) |
+| C99_API_KEY | API key for C99.nl subdomain discovery service. Required for using the C99 reconnaissance tool for DNS enumeration and subdomain discovery. Obtain from [C99.nl](https://c99.nl) | string | Mixed | - |
 
 ---
 
@@ -357,5 +393,6 @@ CAI_MODEL="gpt-4o" CAI_PRICE_LIMIT="2" cai
 ```
 
 **3. Runtime configuration**
-Use CLI commands to modify settings during execution. See [Commands Reference](cai/getting-started/commands.md).
+
+Use slash commands during a session: `/config`, `/config set …`, and the in-session help above (`/help`, `/help var …`). See [Commands Reference](cai/getting-started/commands.md) and [CLI Commands Reference](cli/commands_reference.md).
 


### PR DESCRIPTION
- Document /help, /help var, and /config for in-session env discovery (environment_variables.md, configuration.md, FAQ, CLI reference pages).
- Add Values/When columns and a field guide aligned with REPL /help tables.