### PR TITLE
fix: raise descriptive error when API returns empty choices list

### DIFF
--- a/src/cai/sdk/agents/models/openai_chatcompletions.py
+++ b/src/cai/sdk/agents/models/openai_chatcompletions.py
@@ -721,6 +721,16 @@ class OpenAIChatCompletionsModel(Model):
 
                 raise
 
+            # Guard against empty choices list which can occur with some API providers
+            # (e.g. Gemini via OpenAI-compatible endpoint) due to content filtering or
+            # transient API errors. Raise a clear error instead of an obscure IndexError.
+            if not response.choices:
+                raise ValueError(
+                    f"Model '{self.model}' returned a response with no choices. "
+                    "This may be caused by content filtering, rate limiting, or an "
+                    "API compatibility issue with the provider."
+                )
+
             if _debug.DONT_LOG_MODEL_DATA:
                 logger.debug("Received model response")
             else:


### PR DESCRIPTION
Fixes #415

## Problem

When using OpenAI-compatible API providers (e.g. Google Gemini via its OpenAI-compatible endpoint), the model response can sometimes contain an empty `choices` list due to content filtering, rate limiting, or provider-specific behavior. This caused an obscure `IndexError: list index out of range` deep inside the non-streaming response path in `openai_chatcompletions.py`:

```
File "...openai_chatcompletions.py", line 730, in get_response
    f"LLM resp:\n{json.dumps(response.choices[0].message.model_dump(), indent=2)}\n"
                             ~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

The error was then caught by the main loop and reported repeatedly as `ERROR:cai.cli:Error in main loop: list index out of range`, with no indication of the root cause.

## Solution

Add an explicit guard immediately after receiving the API response (before any code indexes into `response.choices`). When the list is empty, a `ValueError` is raised with a clear, actionable message:

```
ValueError: Model 'openai/gemini-...' returned a response with no choices.
This may be caused by content filtering, rate limiting, or an API compatibility issue with the provider.
```

This replaces the cryptic `IndexError` with a diagnostic message that helps users understand what went wrong and where to look.

## Testing

- Verified the fix is placed before all `response.choices[0]` accesses in the non-streaming path, so the single guard covers all downstream uses.
- The streaming path already guards against empty chunks via `if hasattr(chunk, "choices") and chunk.choices:` (line 1424), so no change needed there.