### PR TITLE
Fix: remove noisy debug print in OpenAI Responses model init

### DIFF
--- a/src/cai/sdk/agents/models/openai_responses.py
+++ b/src/cai/sdk/agents/models/openai_responses.py
@@ -54,7 +54,7 @@ class OpenAIResponsesModel(Model):
         model: str | ChatModel,
         openai_client: AsyncOpenAI,
     ) -> None:
-        print(f"\nDEBUG: OpenAIResponsesModel initialized with model: {model}\n")
+        logger.debug(f"OpenAIResponsesModel initialized with model: {model}")
         self.model = model
         self._client = openai_client
         


### PR DESCRIPTION
# Description
## Summary
This PR removes an always-on `print()` statement from [OpenAIResponsesModel.__init__](cci:1://file:///c:/Users/PAILFAC/Downloads/Clients/Segun/cai/src/cai/sdk/agents/models/openai_responses.py:51:4-65:50) that was polluting CLI output during normal runs.
 
## Changes
- Replaced unconditional `print()` with `logger.debug(...)` so the message is only emitted when debug logging is enabled.
 
## Why
- Prevents unwanted stdout noise for users running the CLI.
- Aligns with the project’s logging practices (debug output should be controlled via logging configuration/env).
 
## Files changed
- [src/cai/sdk/agents/models/openai_responses.py](cci:7://file:///c:/Users/PAILFAC/Downloads/Clients/Segun/cai/src/cai/sdk/agents/models/openai_responses.py:0:0-0:0)
 
## Testing
- Ran the targeted test:
  - `tests/tracing/test_responses_tracing.py`
Feedback submitted