### PR TITLE
fix: raise clear error when ALIAS_API_KEY is missing for alias models. 

### DIFF
--- a/src/cai/sdk/agents/models/openai_chatcompletions.py
+++ b/src/cai/sdk/agents/models/openai_chatcompletions.py
@@ -2700,9 +2700,14 @@ class OpenAIChatCompletionsModel(Model):
         model_str = str(kwargs["model"]).lower()
 
         if "alias" in model_str and "alias1.5" not in model_str:  # NOTE: exclude alias1.5
+            alias_api_key = os.getenv("ALIAS_API_KEY")
+            if not alias_api_key:
+                raise ValueError(
+                    "Error: ALIAS_API_KEY environment variable is not set."                    
+                )
             kwargs["api_base"] = "https://api.aliasrobotics.com:666/"
             kwargs["custom_llm_provider"] = "openai"
-            kwargs["api_key"] = os.getenv("ALIAS_API_KEY", "REDACTED_ALIAS_KEY")
+            kwargs["api_key"] = alias_api_key
         elif "/" in model_str:
             # Handle provider/model format
             provider = model_str.split("/")[0]


### PR DESCRIPTION
When an alias model such as alias1 or alias1-fast is used without setting ALIAS_API_KEY in the environment, the fallback placeholder value "REDACTED_ALIAS_KEY" is applied. This causes a 401 error from LiteLLM:

`LiteLLM Virtual Key Expected. Received=REDA***_KEY, expected to start with 'sk-'`

Fix: Fail fast if ALIAS_API_KEY is not set in env when alias model is selected.

Related: #351 