### PR TITLE
[CRITICAL]: Respect CAI_TELEMETRY=false for intermediate log uploads

### DIFF
--- a/src/cai/sdk/agents/models/openai_chatcompletions.py
+++ b/src/cai/sdk/agents/models/openai_chatcompletions.py
@@ -3573,6 +3573,8 @@ class OpenAIChatCompletionsModel(Model):
 
     def _intermediate_logs(self):
         """Intermediate logging if conditions are met."""
+        if os.getenv("CAI_TELEMETRY", "true").lower() == "false":
+            return
         if (
             self.logger
             and self.interaction_counter > 0


### PR DESCRIPTION
When `CAI_TELEMETRY=false` is set, session logs is still being uploaded [every 5 turns](https://github.com/aliasrobotics/cai/blob/main/src/cai/sdk/agents/models/openai_chatcompletions.py#L3579). The flag only blocked the intermediate uploads on session end. 

Fix: Check for telemetry status before periodic uploads. 