### PR TITLE
fix: correct typo handoff_occured to handoff_occurred

### DIFF
--- a/src/cai/sdk/agents/_run_impl.py
+++ b/src/cai/sdk/agents/_run_impl.py
@@ -1143,7 +1143,7 @@ class RunImpl:
             elif isinstance(item, HandoffCallItem):
                 event = RunItemStreamEvent(item=item, name="handoff_requested")
             elif isinstance(item, HandoffOutputItem):
-                event = RunItemStreamEvent(item=item, name="handoff_occured")
+                event = RunItemStreamEvent(item=item, name="handoff_occurred")
             elif isinstance(item, ToolCallItem):
                 event = RunItemStreamEvent(item=item, name="tool_called")
             elif isinstance(item, ToolCallOutputItem):

--- a/src/cai/sdk/agents/stream_events.py
+++ b/src/cai/sdk/agents/stream_events.py
@@ -31,7 +31,7 @@ class RunItemStreamEvent:
     name: Literal[
         "message_output_created",
         "handoff_requested",
-        "handoff_occured",
+        "handoff_occurred",
         "tool_called",
         "tool_output",
         "reasoning_item_created",


### PR DESCRIPTION
handoff_occured in RunItemStreamEvent's Literal type and the matching event assignment in _run_impl.py was missing the second r. Fixed both sites to handoff_occurred so the string value matches the correct spelling consistently.

