### PR TITLE
fix: guard model registry lookup and prevent silent json serialization failure

### DIFF
--- a/src/cai/parallel_worker.py
+++ b/src/cai/parallel_worker.py
@@ -132,7 +132,7 @@ def main() -> int:
 
     try:
         with open(args.result_file, "w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False)
+            json.dump(payload, f, ensure_ascii=False, default=str)
     except Exception as write_error:  # pylint: disable=broad-except
         print(f"[CAI worker] failed to write result file: {write_error}", file=sys.stderr)
         return 2

--- a/src/cai/tools/streaming.py
+++ b/src/cai/tools/streaming.py
@@ -125,10 +125,13 @@ def _get_agent_token_info():
         from cai.sdk.agents.models.openai_chatcompletions import ACTIVE_MODEL_INSTANCES
 
         if ACTIVE_MODEL_INSTANCES:
-            # Get the most recent instance (highest instance ID)
-            latest_key = max(ACTIVE_MODEL_INSTANCES.keys(), key=lambda x: x[1])
-            model_ref = ACTIVE_MODEL_INSTANCES[latest_key]
-            model = model_ref() if model_ref else None
+            try:
+                # Get the most recent instance (highest instance ID)
+                latest_key = max(ACTIVE_MODEL_INSTANCES.keys(), key=lambda x: x[1])
+                model_ref = ACTIVE_MODEL_INSTANCES.get(latest_key)
+                model = model_ref() if model_ref else None
+            except Exception:
+                model = None
 
             if model:
                 # Get display name with ID


### PR DESCRIPTION
Two defensive fixes in the parallel execution path:

**`tools/streaming.py`**: `_get_agent_token_info()` used direct dict
access (`ACTIVE_MODEL_INSTANCES[key]`) which raises `KeyError` if a
weakref entry is garbage-collected between the emptiness check and the
lookup. The identical logic in `plan.py` already uses `.get()` wrapped
in `try/except` — this makes `streaming.py` consistent with that safe
pattern.

**`parallel_worker.py`**: `json.dump` was called without a `default`
fallback. If any object in `message_history` is not JSON-serializable,
the `TypeError` is caught by the file-write error handler and the entire
worker result is silently lost. Added `default=str` to match the pattern
used in `output.py`.
