### PR TITLE
fix: duplicate litellm stream call doubles provider requests

### DIFF
--- a/src/cai/sdk/agents/models/chatcompletions/litellm_adapter.py
+++ b/src/cai/sdk/agents/models/chatcompletions/litellm_adapter.py
@@ -68,7 +68,6 @@ async def fetch_response_litellm_openai(
     """
     try:
         if stream:
-            ret = await litellm.acompletion(**kwargs)
             stream_obj = await litellm.acompletion(**kwargs)
             return _build_response_obj(model_name, model_settings, tool_choice, parallel_tool_calls), stream_obj
         else:
@@ -102,7 +101,6 @@ async def fetch_response_litellm_openai(
             kwargs["messages"] = messages
 
             if stream:
-                ret = await litellm.acompletion(**kwargs)
                 stream_obj = await litellm.acompletion(**kwargs)
                 return _build_response_obj(model_name, model_settings, tool_choice, parallel_tool_calls), stream_obj
             else:


### PR DESCRIPTION
## Summary

The streaming path in `fetch_response_litellm_openai` called `litellm.acompletion` **twice** with the same kwargs. The first result was assigned to a variable that is never read — only the second call's stream was returned.

## Impact

Every streamed request consumed **two provider requests** (e.g. two NVIDIA NIM requests) with the same API key:

- Halves the effective per-key rate limit (a 40 req/min NIM key only supports 20 streamed turns/min).
- With multi-key round-robin rotation, both calls share the same rotated key, so rotation spreads turns — not requests — and a busy session (several concurrent agents) quickly exhausts both keys → 429 → `LLMRateLimited: Rate limit after 3 attempts`.
- The first call's stream is abandoned, leaking an unconsumed stream on every request.

## Change

Keep a single `litellm.acompletion` call for the streamed path, and the same fix in the `tool_call_id` truncation retry branch (which had the identical double-call pattern).

## Verification

- `stream=True`: one `acompletion` call; the returned stream is the only request sent.
- `stream=False`: unchanged.
- Syntax checked (`ast.parse`); no references to the removed `ret` variable remain.
