### PR TITLE
fix(guard): detect catastrophic 'rm -rf .', '~', '*', '$HOME' (#470)

### DIFF
--- a/src/cai/util/user_prompts.py
+++ b/src/cai/util/user_prompts.py
@@ -53,6 +53,7 @@ import functools
 import getpass
 import os
 import re
+import shlex
 import signal
 import subprocess
 from typing import Any, Callable, Iterator, Tuple
@@ -1288,7 +1289,8 @@ _SENSITIVE_PATTERNS: list[tuple[str, str, str]] = [
     (r"\bdoas\b", "Command uses doas privilege escalation", "sudo"),
 
     # destructive
-    (r"rm\s+(-[^\s]*)*(r|f){2,}.*\s+/", "Recursive/forced removal from root filesystem", "destructive"),
+    # (catastrophic ``rm`` is detected by _is_catastrophic_rm() below -- a regex
+    # here would be filtered out by the "destructive" binary post-check anyway)
     (r"\bmkfs\.", "Command formats a filesystem", "destructive"),
     (r"\bdd\b.*\bof=/dev/", "Direct write to block device (dd)", "destructive"),
     (r"\bwipefs\b", "Command wipes filesystem signatures", "destructive"),
@@ -1567,6 +1569,121 @@ def _is_guard_enabled() -> bool:
     return os.getenv("CAI_SENSITIVE_GUARD", "true").lower() != "false"
 
 
+# --- Catastrophic ``rm`` detection (issue #470) ------------------------------
+# The guard prompts before dangerous operations, but its original ``rm`` regex
+# required the target to contain ``/``, so ``rm -rf .``, ``rm -rf ~`` and
+# ``rm -rf *`` -- the ordinary ways to wipe a working tree or a home directory
+# -- were never detected (a user reported CAI running ``rm -rf .`` and deleting
+# their home directory). This predicate replaces that regex.
+#
+# It is a heuristic for an *interactive confirmation*, not a sandbox. Deliberately
+# obfuscated forms are intentionally out of scope and left to other guards / the
+# model's judgement: command substitution (``$(pwd)``, backticks), wrapper
+# binaries (``env``/``xargs``/``nice`` ...), and non-``rm`` tree deleters
+# (``find ... -delete``).
+_CATASTROPHIC_RM_TARGETS: frozenset[str] = frozenset(
+    {"/", "/*", ".", "..", "~", "*", "$HOME", "$PWD"}
+)
+_CRITICAL_SYSTEM_DIRS: frozenset[str] = frozenset({
+    "/etc", "/home", "/usr", "/var", "/bin", "/sbin", "/lib", "/lib64",
+    "/boot", "/root", "/opt", "/dev", "/proc", "/sys", "/srv", "/mnt", "/media",
+})
+_RM_SEGMENT_SEPARATORS: frozenset[str] = frozenset(
+    {"&&", "||", ";", ";;", "|", "&", "(", ")", "\n"}
+)
+_RM_GLOB_LEAVES: frozenset[str] = frozenset({"*", ".*", ".[!.]*"})
+
+
+def _rm_command_segments(command: str) -> list[list[str]]:
+    """Tokenize *command* and split it into simple-command token lists on shell
+    control operators, quote-aware.
+
+    So ``rm -rf ./build && cd ~`` becomes two segments and the ``~`` from
+    ``cd ~`` is never misread as an ``rm`` target, while a file literally named
+    ``a && b`` stays a single token.
+    """
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            return []
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in _RM_SEGMENT_SEPARATORS:
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _rm_target_is_catastrophic(target: str) -> bool:
+    """True if a single ``rm`` argument denotes a catastrophic location."""
+    norm = target.replace("${HOME}", "$HOME").replace("${PWD}", "$PWD")
+    norm = norm.rstrip("/") or "/"
+    # Peel one trailing glob leaf: ``~/*`` -> ``~``, ``/home/*`` -> ``/home``.
+    if "/" in norm:
+        head, _, leaf = norm.rpartition("/")
+        if head and leaf in _RM_GLOB_LEAVES:
+            norm = head
+    return norm in _CATASTROPHIC_RM_TARGETS or norm in _CRITICAL_SYSTEM_DIRS
+
+
+def _segment_is_catastrophic_rm(tokens: list[str]) -> bool:
+    if not tokens:
+        return False
+    index = 0
+    # Skip leading VAR=value assignments, e.g. ``FOO=bar rm -rf .``.
+    while (
+        index < len(tokens)
+        and "=" in tokens[index]
+        and not tokens[index].startswith("-")
+    ):
+        index += 1
+    if index >= len(tokens) or os.path.basename(tokens[index]) != "rm":
+        return False
+    recursive = False
+    targets: list[str] = []
+    for token in tokens[index + 1:]:
+        if token == "--":
+            continue
+        if token.startswith("--"):
+            if token == "--recursive":
+                recursive = True
+            continue
+        if token.startswith("-") and len(token) > 1:
+            if "r" in token or "R" in token:
+                recursive = True
+            continue
+        targets.append(token)
+    if not recursive:
+        return False
+    return any(_rm_target_is_catastrophic(t) for t in targets)
+
+
+def _is_catastrophic_rm(command: str) -> bool:
+    """True if *command* runs an ``rm`` that recursively/forcibly removes a
+    catastrophic target -- the root filesystem, a top-level system directory,
+    the home directory, the current/parent directory, or a glob of their
+    contents (``rm -rf .`` / ``~`` / ``*`` / ``~/*`` / ``/etc`` ...).
+
+    Deliberately obfuscated forms are out of scope (see the module note above);
+    this only has to catch the ordinary spellings the old regex missed.
+    """
+    return any(
+        _segment_is_catastrophic_rm(segment)
+        for segment in _rm_command_segments(command)
+    )
+
+
 def detect_sensitive_command(command: str) -> tuple[bool, str, str]:
     """Check whether *command* matches any sensitive pattern.
 
@@ -1604,6 +1721,19 @@ def detect_sensitive_command(command: str) -> tuple[bool, str, str]:
                 return (False, "", "")
 
         return (True, reason, category)
+
+    # Catastrophic ``rm`` (issue #470): the patterns above only match targets
+    # containing ``/``, so ``rm -rf .`` / ``~`` / ``*`` slip through. Check for
+    # them here, after the loop, so the ``sudo`` pattern still wins for
+    # ``sudo rm -rf /`` (it matches earlier and returns "sudo").
+    if _is_catastrophic_rm(command):
+        return (
+            True,
+            "Recursive/forced removal of a catastrophic target (the root "
+            "filesystem, a system directory, home, the working directory, or a "
+            "glob of their contents)",
+            "destructive",
+        )
 
     return (False, "", "")
 

--- a/tests/tools/test_catastrophic_rm_guard.py
+++ b/tests/tools/test_catastrophic_rm_guard.py
@@ -1,0 +1,87 @@
+"""Tests for catastrophic ``rm`` detection in the sensitive-command guard (#470).
+
+CAI's guard prompts before dangerous shell commands, but its original ``rm``
+regex only matched targets containing ``/`` -- so ``rm -rf .`` / ``~`` / ``*``
+(the ordinary ways to wipe a working tree or a home directory) slipped through,
+and one such command was reported to have deleted a user's home directory. These
+tests pin the fix: those forms are now detected and prompt, while legitimate
+recursive removals of named sub-paths are left alone.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from cai.util.user_prompts import _is_catastrophic_rm, detect_sensitive_command
+
+
+@pytest.fixture(autouse=True)
+def _guard_enabled():
+    """Ensure the guard is always enabled during tests."""
+    with patch.dict("os.environ", {"CAI_SENSITIVE_GUARD": "true", "CAI_TUI_MODE": "false"}):
+        yield
+
+
+# Commands that must be treated as catastrophic (the guard should prompt).
+CATASTROPHIC = [
+    "rm -rf .", "rm -rf ./", "rm -rf ..", "rm -rf ~", "rm -rf ~/",
+    "rm -rf $HOME", 'rm -rf "$HOME"', "rm -rf ${HOME}", "rm -rf *",
+    "rm -rf /", "rm -rf /*", "rm -fr .", "rm -Rf .", "rm -r -f .",
+    "rm --recursive --force ~", "rm -rf -- .", "FOO=bar rm -rf .",
+    "rm -rf . 2>/dev/null",
+    # top-level system directories
+    "rm -rf /etc", "rm -rf /home", "rm -rf /usr/",
+    # a glob of a catastrophic root's contents
+    "rm -rf ~/*", "rm -rf ./*", "rm -rf /home/*", "rm -rf $HOME/*",
+    # the destructive rm hidden after a leading command in a compound line
+    "cd /tmp && rm -rf ~",
+]
+
+# Legitimate recursive removals that must NOT be flagged.
+LEGIT = [
+    "rm file.txt", "rm -f stale.log", "rm -r mydir", "rm -rf ./build",
+    "rm -rf node_modules", "rm -rf target/debug", "rm -rf /tmp/cai-scratch",
+    "rm -rf /tmp", "rm -rf ~/proj/node_modules", "rm -rf ~/.cache/foo",
+    "rm -rf ./out/", "rm -rf /home/kali/proj/build",
+    # a benign command chained after a legit rm must not be misread as a target
+    "rm -rf ./build && cd ~", "rm -rf ./out; cd /",
+    # not the rm binary
+    "git rm -rf .", "docker rm -f ctr",
+]
+
+
+class TestIsCatastrophicRm:
+    @pytest.mark.parametrize("command", CATASTROPHIC)
+    def test_catastrophic(self, command):
+        assert _is_catastrophic_rm(command) is True
+
+    @pytest.mark.parametrize("command", LEGIT)
+    def test_legit(self, command):
+        assert _is_catastrophic_rm(command) is False
+
+
+class TestDetectSensitiveCommand:
+    @pytest.mark.parametrize("command", CATASTROPHIC)
+    def test_catastrophic_prompts_as_destructive(self, command):
+        is_sensitive, _reason, category = detect_sensitive_command(command)
+        assert is_sensitive
+        assert category == "destructive"
+
+    @pytest.mark.parametrize("command", LEGIT)
+    def test_legit_not_flagged(self, command):
+        is_sensitive, _reason, _category = detect_sensitive_command(command)
+        assert not is_sensitive
+
+    def test_sudo_rm_rf_still_categorised_as_sudo(self):
+        # ``sudo`` is matched earlier in the pattern loop, so it wins and the
+        # command is reported as "sudo" (still prompted), not "destructive".
+        is_sensitive, _reason, category = detect_sensitive_command("sudo rm -rf /")
+        assert is_sensitive
+        assert category == "sudo"
+
+    def test_respects_disabled_guard(self):
+        # When the guard is disabled the catastrophic check must not fire either.
+        with patch.dict("os.environ", {"CAI_SENSITIVE_GUARD": "false"}):
+            is_sensitive, _reason, _category = detect_sensitive_command("rm -rf ~")
+            assert not is_sensitive


### PR DESCRIPTION
## Summary

Fixes #470. CAI's sensitive-command guard is meant to prompt before dangerous
shell commands, but it never prompted on the most common way to wipe data:
**`rm -rf .`, `rm -rf ~`, `rm -rf *`**. A user reported CAI running `rm -rf .`
and deleting their home directory with no confirmation.

## Root cause (`src/cai/util/user_prompts.py`)

Two things meant `rm` was effectively unguarded:

1. The `rm` entry in `_SENSITIVE_PATTERNS` required the target to contain `/`:
   ```python
   (r"rm\s+(-[^\s]*)*(r|f){2,}.*\s+/", "Recursive/forced removal from root filesystem", "destructive"),
   ```
   so `rm -rf .` / `~` / `*` / `$HOME` (no `/`) were never matched.
2. Even the forms it *did* match textually (`rm -rf /`) never actually prompted:
   the `destructive` category is refined by a binary post-check in
   `detect_sensitive_command` (`_DESTRUCTIVE_TOOL_NAMES = {mkfs, wipefs, fdisk,
   parted, shred}`), and `rm` isn't in that set, so the match is filtered out
   before it can prompt. (Your own `test_sensitive_guard_false_positives.py`
   documents this post-check.) In practice the `rm` pattern never fired.

Net effect: no `rm` command prompted, including `rm -rf .` in #470.

## Fix — a small predicate, not a regex

Add `_is_catastrophic_rm(command)`, checked *after* the pattern loop so
`sudo rm -rf /` still resolves to the `sudo` category (it matches earlier). It
shlex-tokenizes, splits on shell operators (`&&`, `||`, `;`, `|`), and flags a
**recursive** `rm` whose target is a catastrophic root (`.`, `..`, `~`, `$HOME`,
`*`, `/`) or a top-level system directory (`/etc`, `/home`, …), including a glob
of their contents (`~/*`, `./*`, `/home/*`).

It still **prompts** (never hard-blocks), and the guard still fails safe on the
headless-menu timeout — so this changes detection only, consistent with every
other pattern.

## Coverage (before → after)

| command | before | after |
|---|---|---|
| `rm -rf .`  (the #470 command) | no prompt | **prompt** |
| `rm -rf ~` · `rm -rf *` · `rm -rf $HOME` | no prompt | **prompt** |
| `rm -rf ~/*` · `rm -rf /home/*` | no prompt | **prompt** |
| `rm -rf /etc` · `rm -rf /` | no prompt¹ | **prompt** |
| `rm -rf ./build` · `rm -rf /tmp/scratch`  (legit) | no prompt | no prompt |
| `rm -rf ./build && cd ~`  (legit compound) | no prompt | no prompt |
| `sudo rm -rf /` | prompt (sudo) | prompt (sudo) |

¹ matched the old regex textually but was filtered by the `destructive`
binary post-check, so it never prompted.

The fix **adds** a prompt for the bare catastrophic forms (that's the point of
#470) while leaving legitimate named sub-paths (`./build`, `/tmp/scratch`,
`node_modules`, …) unflagged — no new false positives, verified by the tests.

## Tests

`tests/tools/test_catastrophic_rm_guard.py` — parametrized catastrophic vs.
legitimate commands, asserted through both `_is_catastrophic_rm` and
`detect_sensitive_command` (category `destructive`), plus `sudo rm -rf /` still
`sudo` and the disabled-guard path. The existing
`test_sensitive_guard_false_positives.py` keeps passing.

## Scope / notes

- A heuristic for an interactive confirmation, not a sandbox. Deliberately
  obfuscated forms are out of scope, left to other guards / the model's
  judgement: command substitution (`$(pwd)`), wrapper binaries (`env rm`,
  `xargs rm`), and non-`rm` tree deleters (`find … -delete`).
- Bare `rm -rf *` / `rm -rf .` now prompt in cleanup flows too — intended; those
  are exactly the forms that wiped a home directory. Named targets don't prompt.
- The system-directory list is exact-match (every sub-path passes); happy to
  narrow it if you'd prefer a smaller set.

Fixes #470
